### PR TITLE
Compile Paraglide artifacts before TypeScript typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
     "dev": "vite",
     "build": "vite build && tsc -b",
     "preview": "vite preview",
-    "typecheck": "tsc -b --noEmit",
+    "typecheck": "npm run i18n:compile && tsc -b --noEmit",
     "lint": "oxlint",
     "format": "oxfmt .",
     "test": "vitest run",
     "test:ui": "vitest --ui",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "i18n:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide"
   },
   "dependencies": {
     "bootstrap": "^5.3.8",


### PR DESCRIPTION
### Motivation
- Typechecking failed because generated Paraglide artifacts under `src/paraglide` were missing, causing `tsc` to error on imports like `./paraglide/messages.js` and `./paraglide/runtime.js`.

### Description
- Add an `i18n:compile` script that runs `paraglide-js compile --project ./project.inlang --outdir ./src/paraglide` and update the `typecheck` script to run `npm run i18n:compile && tsc -b --noEmit` so Paraglide artifacts are generated before TypeScript checks.

### Testing
- Before the change `npm run typecheck` failed with missing module errors, and after the change `npm run typecheck` (which runs the new `i18n:compile`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a752e4db78832eb99519d0ec6e5dd2)