### PR TITLE
Potential fix for code scanning alert no. 1: Clear text storage of sensitive information

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,35 +119,29 @@ function sanitizeInputs(raw: unknown): TaxInputs {
   };
 }
 
-type PersistedInputs = Omit<
+type PersistedInputs = Pick<
   TaxInputs,
-  | "grossSalary"
-  | "daysWorkedNL"
-  | "daysWorkedBE"
-  | "daysWorkedOther"
-  | "sickDays"
-  | "socialContributions"
-  | "aanvullendPensioen"
-  | "dienstencheques"
-  | "roerendeVoorheffing"
-  | "withheldTaxNL"
+  | "year"
+  | "residentCountry"
+  | "civilStatus"
+  | "dependentChildren"
+  | "belowAOWAge"
+  | "belgianRegion"
+  | "communalTaxRate"
+  | "thirtyPercentRuling"
 >;
 
 function toPersistedInputs(inputs: TaxInputs): PersistedInputs {
-  const {
-    grossSalary: _grossSalary,
-    daysWorkedNL: _daysWorkedNL,
-    daysWorkedBE: _daysWorkedBE,
-    daysWorkedOther: _daysWorkedOther,
-    sickDays: _sickDays,
-    socialContributions: _socialContributions,
-    aanvullendPensioen: _aanvullendPensioen,
-    dienstencheques: _dienstencheques,
-    roerendeVoorheffing: _roerendeVoorheffing,
-    withheldTaxNL: _withheldTaxNL,
-    ...rest
-  } = inputs;
-  return rest;
+  return {
+    year: inputs.year,
+    residentCountry: inputs.residentCountry,
+    civilStatus: inputs.civilStatus,
+    dependentChildren: inputs.dependentChildren,
+    belowAOWAge: inputs.belowAOWAge,
+    belgianRegion: inputs.belgianRegion,
+    communalTaxRate: inputs.communalTaxRate,
+    thirtyPercentRuling: inputs.thirtyPercentRuling,
+  };
 }
 
 function mergeWithDefaults(raw: unknown): TaxInputs {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,6 +119,54 @@ function sanitizeInputs(raw: unknown): TaxInputs {
   };
 }
 
+type PersistedInputs = Omit<
+  TaxInputs,
+  | "grossSalary"
+  | "daysWorkedNL"
+  | "daysWorkedBE"
+  | "daysWorkedOther"
+  | "sickDays"
+  | "socialContributions"
+  | "aanvullendPensioen"
+  | "dienstencheques"
+  | "roerendeVoorheffing"
+  | "withheldTaxNL"
+>;
+
+function toPersistedInputs(inputs: TaxInputs): PersistedInputs {
+  const {
+    grossSalary: _grossSalary,
+    daysWorkedNL: _daysWorkedNL,
+    daysWorkedBE: _daysWorkedBE,
+    daysWorkedOther: _daysWorkedOther,
+    sickDays: _sickDays,
+    socialContributions: _socialContributions,
+    aanvullendPensioen: _aanvullendPensioen,
+    dienstencheques: _dienstencheques,
+    roerendeVoorheffing: _roerendeVoorheffing,
+    withheldTaxNL: _withheldTaxNL,
+    ...rest
+  } = inputs;
+  return rest;
+}
+
+function mergeWithDefaults(raw: unknown): TaxInputs {
+  const sanitized = sanitizeInputs(raw);
+  return {
+    ...sanitized,
+    grossSalary: DEFAULT_INPUTS.grossSalary,
+    daysWorkedNL: DEFAULT_INPUTS.daysWorkedNL,
+    daysWorkedBE: DEFAULT_INPUTS.daysWorkedBE,
+    daysWorkedOther: DEFAULT_INPUTS.daysWorkedOther,
+    sickDays: DEFAULT_INPUTS.sickDays,
+    socialContributions: DEFAULT_INPUTS.socialContributions,
+    aanvullendPensioen: DEFAULT_INPUTS.aanvullendPensioen,
+    dienstencheques: DEFAULT_INPUTS.dienstencheques,
+    roerendeVoorheffing: DEFAULT_INPUTS.roerendeVoorheffing,
+    withheldTaxNL: DEFAULT_INPUTS.withheldTaxNL,
+  };
+}
+
 function loadInitialInputs(): TaxInputs {
   const saved = localStorage.getItem(STORAGE_KEY);
   if (!saved) {
@@ -126,7 +174,7 @@ function loadInitialInputs(): TaxInputs {
   }
 
   try {
-    return sanitizeInputs(JSON.parse(saved));
+    return mergeWithDefaults(JSON.parse(saved));
   } catch {
     return DEFAULT_INPUTS;
   }
@@ -148,7 +196,7 @@ export default function App() {
   );
 
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(inputs));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(toPersistedInputs(inputs)));
   }, [inputs]);
 
   return (


### PR DESCRIPTION
Potential fix for [https://github.com/tjorim/bordertax/security/code-scanning/1](https://github.com/tjorim/bordertax/security/code-scanning/1)

The best fix without changing core functionality is to **stop persisting sensitive fields** (especially `grossSalary`) and only store non-sensitive preferences/selection fields in `localStorage`. This avoids brittle client-side encryption/key-management problems in browser code and still preserves most UX benefits.

In `src/App.tsx`:
1. Introduce a small persisted-shape type that omits sensitive numeric income/work fields.
2. Add helper functions:
   - `toPersistedInputs(inputs)` to strip sensitive fields before storage.
   - `mergeWithDefaults(raw)` to sanitize and then force sensitive fields back to safe defaults when loading.
3. Update `loadInitialInputs()` to use `mergeWithDefaults(JSON.parse(saved))` instead of returning `sanitizeInputs(...)` directly.
4. Update the `useEffect` writer to store `JSON.stringify(toPersistedInputs(inputs))` instead of full `inputs`.

This preserves existing behavior for non-sensitive remembered settings while ensuring cleartext salary is never written to storage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
