### PR TITLE
feat: teal brand palette + light/dark/auto theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,12 @@
     />
     <script>
       (function () {
-        var stored = localStorage.getItem("bt-theme");
+        var stored;
+        try {
+          stored = localStorage.getItem("bt-theme");
+        } catch (e) {
+          stored = null;
+        }
         var prefersDark =
           typeof window.matchMedia === "function" &&
           window.matchMedia("(prefers-color-scheme: dark)").matches;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -9,8 +9,20 @@
       name="description"
       content="Tax calculator for Belgian residents working in the Netherlands — NL Box 1 income tax and Belgian personenbelasting via exemption with progression."
     />
-    <meta name="theme-color" content="#07090f" />
-    <meta name="color-scheme" content="dark" />
+    <script>
+      (function () {
+        var stored = localStorage.getItem("bt-theme");
+        var effective =
+          stored === "light"
+            ? "light"
+            : stored === "dark"
+              ? "dark"
+              : window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light";
+        document.documentElement.setAttribute("data-bs-theme", effective);
+      })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/index.html
+++ b/index.html
@@ -12,14 +12,11 @@
     <script>
       (function () {
         var stored = localStorage.getItem("bt-theme");
+        var prefersDark =
+          typeof window.matchMedia === "function" &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches;
         var effective =
-          stored === "light"
-            ? "light"
-            : stored === "dark"
-              ? "dark"
-              : window.matchMedia("(prefers-color-scheme: dark)").matches
-                ? "dark"
-                : "light";
+          stored === "light" ? "light" : stored === "dark" ? "dark" : prefersDark ? "dark" : "light";
         document.documentElement.setAttribute("data-bs-theme", effective);
       })();
     </script>

--- a/messages/en.json
+++ b/messages/en.json
@@ -590,5 +590,8 @@
   "theme_toggle_label": "Theme",
   "theme_auto": "auto",
   "theme_light": "light",
-  "theme_dark": "dark"
+  "theme_dark": "dark",
+  "results_error_title": "Something went wrong",
+  "results_error_description": "The tax calculation encountered an unexpected error. Try adjusting your inputs.",
+  "results_error_details": "Technical details"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -586,5 +586,9 @@
   "ref_pension_be2027_age_62": "62 years",
   "ref_pension_be2027_age_63": "63 years",
   "ref_pension_be2027_age_64": "64 years",
-  "ref_pension_be2027_age_65": "65 years"
+  "ref_pension_be2027_age_65": "65 years",
+  "theme_toggle_label": "Theme",
+  "theme_auto": "auto",
+  "theme_light": "light",
+  "theme_dark": "dark"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -590,5 +590,8 @@
   "theme_toggle_label": "Thema",
   "theme_auto": "auto",
   "theme_light": "licht",
-  "theme_dark": "donker"
+  "theme_dark": "donker",
+  "results_error_title": "Er ging iets mis",
+  "results_error_description": "De belastingberekening is vastgelopen. Probeer je gegevens aan te passen.",
+  "results_error_details": "Technische details"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -586,5 +586,9 @@
   "ref_pension_be2027_age_62": "62 jaar",
   "ref_pension_be2027_age_63": "63 jaar",
   "ref_pension_be2027_age_64": "64 jaar",
-  "ref_pension_be2027_age_65": "65 jaar"
+  "ref_pension_be2027_age_65": "65 jaar",
+  "theme_toggle_label": "Thema",
+  "theme_auto": "auto",
+  "theme_light": "licht",
+  "theme_dark": "donker"
 }

--- a/package.json
+++ b/package.json
@@ -34,12 +34,17 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
+    "@tanstack/react-form": "^1.33.0",
     "@tanstack/react-router": "^1.170.9",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
+    "clsx": "^2.1.1",
     "react": "^19.2.6",
-    "react-bootstrap": "^2.10.10",
-    "react-dom": "^19.2.6"
+    "react-bootstrap": "3.0.0-beta.5",
+    "react-dom": "^19.2.6",
+    "react-error-boundary": "^6.1.2",
+    "recharts": "^3.8.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@inlang/paraglide-js": "^2.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
+      '@tanstack/react-form':
+        specifier: ^1.33.0
+        version: 1.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-router':
         specifier: ^1.170.9
         version: 1.170.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -20,15 +23,27 @@ importers:
       bootstrap-icons:
         specifier: ^1.13.1
         version: 1.13.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       react:
         specifier: ^19.2.6
         version: 19.2.6
       react-bootstrap:
-        specifier: ^2.10.10
-        version: 2.10.10(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.0.0-beta.5
+        version: 3.0.0-beta.5(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
+      react-error-boundary:
+        specifier: ^6.1.2
+        version: 6.1.2(react@19.2.6)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@inlang/paraglide-js':
         specifier: ^2.18.1
@@ -444,27 +459,27 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
-  '@react-aria/ssr@3.9.10':
-    resolution: {integrity: sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==}
-    engines: {node: '>= 12'}
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
 
-  '@restart/hooks@0.4.16':
-    resolution: {integrity: sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==}
+  '@restart/hooks@0.6.2':
+    resolution: {integrity: sha512-0QzYBe1raty/ULcuyTk0ZdLf+e//4n/f39hDPt5JYZW5kSbHEAgnZhLpWErCKEYSzi14oVBSbNsllnJmWlloBg==}
     peerDependencies:
       react: '>=16.8.0'
 
-  '@restart/hooks@0.5.1':
-    resolution: {integrity: sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==}
+  '@restart/ui@2.0.0-beta.12':
+    resolution: {integrity: sha512-C8M1Ecgsemp4kjUOmsxafQOpoetcrROGtGAW9sHAQ71wdNbO4xMk4QdunmxZxTrsHypPJh3wNmlaxgBKhlrz2g==}
     peerDependencies:
-      react: '>=16.8.0'
-
-  '@restart/ui@1.9.4':
-    resolution: {integrity: sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==}
-    peerDependencies:
-      react: '>=16.14.0'
-      react-dom: '>=16.14.0'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   '@rolldown/binding-android-arm64@1.0.2':
     resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
@@ -574,12 +589,33 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@swc/helpers@0.5.19':
-    resolution: {integrity: sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==}
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@tanstack/devtools-event-client@0.4.3':
+    resolution: {integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@tanstack/form-core@1.33.0':
+    resolution: {integrity: sha512-AV4Pw9Dk4orFsuPBcDssfWMJFs+yMYBae7zZ4oTqrCf4ftNGQKxvrQRZeqKHG6A4TkiLeSvf2kzIjcVkrW7E6w==}
 
   '@tanstack/history@1.162.0':
     resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
     engines: {node: '>=20.19'}
+
+  '@tanstack/pacer-lite@0.1.1':
+    resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
+    engines: {node: '>=18'}
+
+  '@tanstack/react-form@1.33.0':
+    resolution: {integrity: sha512-unaee+VS4MvKo+s1dmgGUXI4902VeAhuaUbKsQbhFe3MceOpB3JpAUGCDpyzjQPXVFkFY0COKfLrUNX2XZYW4g==}
+    peerDependencies:
+      '@tanstack/react-start': '*'
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@tanstack/react-start':
+        optional: true
 
   '@tanstack/react-router@1.170.9':
     resolution: {integrity: sha512-rXXztp6GyXFwResQR0jdvkf52wy/sAQqze3OR08+8uNM7nHir1P46qBrwg2TL5EEtX+0WUho4BZ/nMpAgQVB6A==}
@@ -587,6 +623,12 @@ packages:
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.11.0':
+    resolution: {integrity: sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@tanstack/react-store@0.9.3':
     resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
@@ -597,6 +639,9 @@ packages:
   '@tanstack/router-core@1.171.7':
     resolution: {integrity: sha512-AboyQD0OPIu0adJi6HeCupTU9Wx7zr4q4ceJYQdBL3mLH18m4M57XXdzJdtzOg/twl8DtWej0RGJ12ma8CV1iQ==}
     engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.11.0':
+    resolution: {integrity: sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw==}
 
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
@@ -633,6 +678,33 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -641,9 +713,6 @@ packages:
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
-
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -657,6 +726,9 @@ packages:
 
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/warning@3.0.4':
     resolution: {integrity: sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==}
@@ -768,8 +840,9 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
-  classnames@2.5.1:
-    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -798,6 +871,53 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   dedent@1.5.1:
     resolution: {integrity: sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==}
     peerDependencies:
@@ -823,12 +943,18 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dom-helpers@6.0.1:
+    resolution: {integrity: sha512-IKySryuFwseGkrCA/pIqlwUPOD50w1Lj/B2Yief3vBOP18k5y4t+hTqKh55gULDVeJMRitcozve+g/wVFf4sFQ==}
+
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -837,6 +963,9 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -882,9 +1011,19 @@ packages:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.8:
+    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -1079,20 +1218,15 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
-  prop-types-extra@1.1.1:
-    resolution: {integrity: sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==}
-    peerDependencies:
-      react: '>=0.14.0'
-
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  react-bootstrap@2.10.10:
-    resolution: {integrity: sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==}
+  react-bootstrap@3.0.0-beta.5:
+    resolution: {integrity: sha512-/hlkMPx8DVl3qhYORYDuQ1xxktvYP1dHTKd7OHGqROugHUI3kIgl4nuwx5XT3+WQpOnOmHN2R3hrtgVP72aoNw==}
     peerDependencies:
-      '@types/react': '>=16.14.8'
-      react: '>=16.14.0'
-      react-dom: '>=16.14.0'
+      '@types/react': '>=18.3.12'
+      react: '>=18.3.1'
+      react-dom: '>=18.3.1'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1102,14 +1236,28 @@ packages:
     peerDependencies:
       react: ^19.2.6
 
+  react-error-boundary@6.1.2:
+    resolution: {integrity: sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-lifecycles-compat@3.0.4:
-    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -1121,9 +1269,28 @@ packages:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   rolldown@1.0.2:
     resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
@@ -1190,6 +1357,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1221,13 +1391,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  uncontrollable@7.2.1:
-    resolution: {integrity: sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==}
-    peerDependencies:
-      react: '>=15.0.0'
-
-  uncontrollable@8.0.4:
-    resolution: {integrity: sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==}
+  uncontrollable@9.0.0:
+    resolution: {integrity: sha512-wPScOFmvRkHdvebf7qNPn9Wog9B1TL8Dqcx0Vecz6HYTKFKMfGKP6MJHTjiKL8kwd8KTW3YfIUke7pmRDtkcRQ==}
     peerDependencies:
       react: '>=16.14.0'
 
@@ -1249,6 +1414,9 @@ packages:
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@8.0.14:
     resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
@@ -1360,6 +1528,9 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1609,33 +1780,34 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@react-aria/ssr@3.9.10(react@19.2.6)':
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1))(react@19.2.6)':
     dependencies:
-      '@swc/helpers': 0.5.19
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.8
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
       react: 19.2.6
+      react-redux: 9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1)
 
-  '@restart/hooks@0.4.16(react@19.2.6)':
+  '@restart/hooks@0.6.2(react@19.2.6)':
     dependencies:
       dequal: 2.0.3
       react: 19.2.6
 
-  '@restart/hooks@0.5.1(react@19.2.6)':
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.6
-
-  '@restart/ui@1.9.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@restart/ui@2.0.0-beta.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@popperjs/core': 2.11.8
-      '@react-aria/ssr': 3.9.10(react@19.2.6)
-      '@restart/hooks': 0.5.1(react@19.2.6)
+      '@restart/hooks': 0.6.2(react@19.2.6)
       '@types/warning': 3.0.4
       dequal: 2.0.3
-      dom-helpers: 5.2.1
+      dom-helpers: 6.0.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      uncontrollable: 8.0.4(react@19.2.6)
+      uncontrollable: 9.0.0(react@19.2.6)
       warning: 4.0.3
 
   '@rolldown/binding-android-arm64@1.0.2':
@@ -1695,11 +1867,27 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@swc/helpers@0.5.19':
+  '@standard-schema/utils@0.3.0': {}
+
+  '@tanstack/devtools-event-client@0.4.3': {}
+
+  '@tanstack/form-core@1.33.0':
     dependencies:
-      tslib: 2.8.1
+      '@tanstack/devtools-event-client': 0.4.3
+      '@tanstack/pacer-lite': 0.1.1
+      '@tanstack/store': 0.11.0
 
   '@tanstack/history@1.162.0': {}
+
+  '@tanstack/pacer-lite@0.1.1': {}
+
+  '@tanstack/react-form@1.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/form-core': 1.33.0
+      '@tanstack/react-store': 0.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+    transitivePeerDependencies:
+      - react-dom
 
   '@tanstack/react-router@1.170.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -1709,6 +1897,13 @@ snapshots:
       isbot: 5.1.40
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+
+  '@tanstack/react-store@0.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/store': 0.11.0
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
 
   '@tanstack/react-store@0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -1723,6 +1918,8 @@ snapshots:
       cookie-es: 3.1.1
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/store@0.11.0': {}
 
   '@tanstack/store@0.9.3': {}
 
@@ -1768,6 +1965,30 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
@@ -1775,8 +1996,6 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
-
-  '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.15)':
     dependencies:
@@ -1789,6 +2008,8 @@ snapshots:
   '@types/react@19.2.15':
     dependencies:
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/warning@3.0.4': {}
 
@@ -1901,7 +2122,7 @@ snapshots:
 
   chai@6.2.2: {}
 
-  classnames@2.5.1: {}
+  clsx@2.1.1: {}
 
   commander@11.1.0: {}
 
@@ -1922,6 +2143,46 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  decimal.js-light@2.5.1: {}
+
   dedent@1.5.1: {}
 
   dequal@2.0.3: {}
@@ -1937,15 +2198,24 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
+  dom-helpers@6.0.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
+
   entities@7.0.1: {}
 
   es-module-lexer@2.1.0: {}
+
+  es-toolkit@1.47.0: {}
 
   esprima@4.0.1: {}
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  eventemitter3@5.0.4: {}
 
   expect-type@1.3.0: {}
 
@@ -1980,7 +2250,13 @@ snapshots:
 
   human-id@4.1.3: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.8: {}
+
   indent-string@4.0.0: {}
+
+  internmap@2.0.3: {}
 
   invariant@2.2.4:
     dependencies:
@@ -2154,34 +2430,25 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  prop-types-extra@1.1.1(react@19.2.6):
-    dependencies:
-      react: 19.2.6
-      react-is: 16.13.1
-      warning: 4.0.3
-
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  react-bootstrap@2.10.10(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-bootstrap@3.0.0-beta.5(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@restart/hooks': 0.4.16(react@19.2.6)
-      '@restart/ui': 1.9.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@types/prop-types': 15.7.15
+      '@restart/hooks': 0.6.2(react@19.2.6)
+      '@restart/ui': 2.0.0-beta.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/react-transition-group': 4.4.12(@types/react@19.2.15)
-      classnames: 2.5.1
-      dom-helpers: 5.2.1
+      clsx: 2.1.1
+      dom-helpers: 6.0.1
       invariant: 2.2.4
-      prop-types: 15.8.1
-      prop-types-extra: 1.1.1(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-transition-group: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      uncontrollable: 7.2.1(react@19.2.6)
+      uncontrollable: 9.0.0(react@19.2.6)
       warning: 4.0.3
     optionalDependencies:
       '@types/react': 19.2.15
@@ -2191,11 +2458,22 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
+  react-error-boundary@6.1.2(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
 
-  react-lifecycles-compat@3.0.4: {}
+  react-redux@9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      redux: 5.0.1
 
   react-transition-group@4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -2208,10 +2486,38 @@ snapshots:
 
   react@19.2.6: {}
 
+  recharts@3.8.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1))(react@19.2.6)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.47.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-is: 17.0.2
+      react-redux: 9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.6)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
+  reselect@5.1.1: {}
 
   rolldown@1.0.2:
     dependencies:
@@ -2285,6 +2591,8 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.2: {}
@@ -2300,19 +2608,12 @@ snapshots:
 
   totalist@3.0.1: {}
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   typescript@6.0.3: {}
 
-  uncontrollable@7.2.1(react@19.2.6):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@types/react': 19.2.15
-      invariant: 2.2.4
-      react: 19.2.6
-      react-lifecycles-compat: 3.0.4
-
-  uncontrollable@8.0.4(react@19.2.6):
+  uncontrollable@9.0.0(react@19.2.6):
     dependencies:
       react: 19.2.6
 
@@ -2332,6 +2633,23 @@ snapshots:
       react: 19.2.6
 
   uuid@14.0.0: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@8.0.14(@types/node@25.9.1)(terser@5.48.0):
     dependencies:
@@ -2389,3 +2707,5 @@ snapshots:
       stackback: 0.0.2
 
   ws@8.20.0: {}
+
+  zod@4.4.3: {}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,10 +174,43 @@ function loadInitialInputs(): TaxInputs {
   }
 }
 
+type Theme = "auto" | "light" | "dark";
+const THEME_KEY = "bt-theme";
+
+function loadTheme(): Theme {
+  const stored = localStorage.getItem(THEME_KEY);
+  return stored === "light" || stored === "dark" || stored === "auto" ? stored : "auto";
+}
+
+function applyTheme(theme: Theme) {
+  const effective =
+    theme === "auto"
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light"
+      : theme;
+  document.documentElement.setAttribute("data-bs-theme", effective);
+}
+
+const THEME_CYCLE: Theme[] = ["auto", "light", "dark"];
+
 export default function App() {
   const [inputs, setInputs] = useState<TaxInputs>(loadInitialInputs);
   const [locale, setCurrentLocale] = useState(getLocale());
+  const [theme, setTheme] = useState<Theme>(loadTheme);
   const nextLangLabel = locale === "en" ? m.lang_nl() : m.lang_en();
+
+  useEffect(() => {
+    applyTheme(theme);
+    localStorage.setItem(THEME_KEY, theme);
+
+    if (theme === "auto") {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      const handler = () => applyTheme("auto");
+      mq.addEventListener("change", handler);
+      return () => mq.removeEventListener("change", handler);
+    }
+  }, [theme]);
 
   const result = useMemo(() => calculate(inputs), [inputs]);
   const comparisonResults = useMemo(
@@ -208,9 +241,24 @@ export default function App() {
             </span>
           </Link>
           <Button
-            variant="outline-light"
+            variant="outline-secondary"
             size="sm"
-            className="ms-3"
+            className="ms-2"
+            onClick={() => {
+              const idx = THEME_CYCLE.indexOf(theme);
+              setTheme(THEME_CYCLE[(idx + 1) % THEME_CYCLE.length]);
+            }}
+            aria-label={`Theme: ${theme}`}
+            title={`Theme: ${theme} (click to cycle)`}
+          >
+            <i
+              className={`bi ${theme === "light" ? "bi-sun-fill" : theme === "dark" ? "bi-moon-fill" : "bi-circle-half"}`}
+            />
+          </Button>
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            className="ms-2"
             onClick={() => {
               const nextLocale = locale === "en" ? "nl" : "en";
               setLocale(nextLocale, { reload: false });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { Link } from "@tanstack/react-router";
+import { useForm, useStore } from "@tanstack/react-form";
 import { useEffect, useMemo, useState } from "react";
 import { Button, Col, Container, Nav, Navbar, Row, Tab } from "react-bootstrap";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "bootstrap-icons/font/bootstrap-icons.css";
 import "./styles.css";
@@ -13,26 +15,12 @@ import MultiYearComparison from "./components/MultiYearComparison";
 import WFHRatioChart from "./components/WFHRatioChart";
 import { calculate } from "./tax";
 import type { TaxInputs } from "./tax/types";
-import {
-  VALID_BELGIAN_REGIONS,
-  VALID_CIVIL_STATUSES,
-  VALID_RESIDENT_COUNTRIES,
-  VALID_YEARS,
-} from "./tax/constants";
+import { VALID_YEARS } from "./tax/constants";
+import { TaxInputSchema, PersistedInputsSchema, type PersistedInputs } from "./tax/schema";
 import * as m from "./paraglide/messages.js";
 import { getLocale, setLocale } from "./paraglide/runtime.js";
 
-type TaxInputsWithRequiredBEDeductions = TaxInputs & {
-  socialContributions: number;
-  aanvullendPensioen: number;
-  dienstencheques: number;
-  roerendeVoorheffing: number;
-  withheldTaxNL: number;
-  daysWorkedOther: number;
-  sickDays: number;
-};
-
-const DEFAULT_INPUTS: TaxInputsWithRequiredBEDeductions = {
+const DEFAULT_INPUTS: TaxInputs = {
   year: 2025,
   residentCountry: "BE",
   civilStatus: "single",
@@ -55,110 +43,13 @@ const DEFAULT_INPUTS: TaxInputsWithRequiredBEDeductions = {
 
 const STORAGE_KEY = "grensarbeider-tax-inputs-v1";
 
-function sanitizeInputs(raw: unknown): TaxInputs {
-  if (!raw || typeof raw !== "object") {
-    return DEFAULT_INPUTS;
-  }
-
-  const input = raw as Partial<TaxInputs>;
-
-  const isOneOf = <T,>(value: unknown, options: readonly T[]): value is T =>
-    options.includes(value as T);
-
-  const sanitizeNonNegative = (value: unknown, defaultValue: number): number =>
-    Number.isFinite(value) ? Math.max(0, Number(value)) : defaultValue;
-
-  return {
-    year: isOneOf(input.year, VALID_YEARS) ? input.year : DEFAULT_INPUTS.year,
-    residentCountry: isOneOf(input.residentCountry, VALID_RESIDENT_COUNTRIES)
-      ? input.residentCountry
-      : DEFAULT_INPUTS.residentCountry,
-    civilStatus: isOneOf(input.civilStatus, VALID_CIVIL_STATUSES)
-      ? input.civilStatus
-      : DEFAULT_INPUTS.civilStatus,
-    dependentChildren: Number.isFinite(input.dependentChildren)
-      ? Math.min(10, Math.max(0, Number(input.dependentChildren)))
-      : DEFAULT_INPUTS.dependentChildren,
-    belowAOWAge:
-      typeof input.belowAOWAge === "boolean" ? input.belowAOWAge : DEFAULT_INPUTS.belowAOWAge,
-    belgianRegion: isOneOf(input.belgianRegion, VALID_BELGIAN_REGIONS)
-      ? input.belgianRegion
-      : DEFAULT_INPUTS.belgianRegion,
-    communalTaxRate: Number.isFinite(input.communalTaxRate)
-      ? Math.min(15, Math.max(0, Number(input.communalTaxRate)))
-      : DEFAULT_INPUTS.communalTaxRate,
-    grossSalary: Number.isFinite(input.grossSalary)
-      ? Math.max(0, Number(input.grossSalary))
-      : DEFAULT_INPUTS.grossSalary,
-    daysWorkedNL: Number.isFinite(input.daysWorkedNL)
-      ? Math.max(0, Number(input.daysWorkedNL))
-      : DEFAULT_INPUTS.daysWorkedNL,
-    daysWorkedBE: Number.isFinite(input.daysWorkedBE)
-      ? Math.max(0, Number(input.daysWorkedBE))
-      : DEFAULT_INPUTS.daysWorkedBE,
-    daysWorkedOther: sanitizeNonNegative(input.daysWorkedOther, DEFAULT_INPUTS.daysWorkedOther),
-    thirtyPercentRuling:
-      typeof input.thirtyPercentRuling === "boolean"
-        ? input.thirtyPercentRuling
-        : DEFAULT_INPUTS.thirtyPercentRuling,
-    socialContributions: sanitizeNonNegative(
-      input.socialContributions,
-      DEFAULT_INPUTS.socialContributions,
-    ),
-    aanvullendPensioen: sanitizeNonNegative(
-      input.aanvullendPensioen,
-      DEFAULT_INPUTS.aanvullendPensioen,
-    ),
-    dienstencheques: sanitizeNonNegative(input.dienstencheques, DEFAULT_INPUTS.dienstencheques),
-    roerendeVoorheffing: sanitizeNonNegative(
-      input.roerendeVoorheffing,
-      DEFAULT_INPUTS.roerendeVoorheffing,
-    ),
-    withheldTaxNL: sanitizeNonNegative(input.withheldTaxNL, DEFAULT_INPUTS.withheldTaxNL),
-    sickDays: sanitizeNonNegative(input.sickDays, DEFAULT_INPUTS.sickDays),
-  };
-}
-
-type PersistedInputs = Pick<
-  TaxInputs,
-  | "year"
-  | "residentCountry"
-  | "civilStatus"
-  | "dependentChildren"
-  | "belowAOWAge"
-  | "belgianRegion"
-  | "communalTaxRate"
-  | "thirtyPercentRuling"
->;
-
 function toPersistedInputs(inputs: TaxInputs): PersistedInputs {
-  return {
-    year: inputs.year,
-    residentCountry: inputs.residentCountry,
-    civilStatus: inputs.civilStatus,
-    dependentChildren: inputs.dependentChildren,
-    belowAOWAge: inputs.belowAOWAge,
-    belgianRegion: inputs.belgianRegion,
-    communalTaxRate: inputs.communalTaxRate,
-    thirtyPercentRuling: inputs.thirtyPercentRuling,
-  };
+  return PersistedInputsSchema.parse(inputs);
 }
 
 function mergeWithDefaults(raw: unknown): TaxInputs {
-  const sanitized = sanitizeInputs(raw);
-  return {
-    ...sanitized,
-    grossSalary: DEFAULT_INPUTS.grossSalary,
-    daysWorkedNL: DEFAULT_INPUTS.daysWorkedNL,
-    daysWorkedBE: DEFAULT_INPUTS.daysWorkedBE,
-    daysWorkedOther: DEFAULT_INPUTS.daysWorkedOther,
-    sickDays: DEFAULT_INPUTS.sickDays,
-    socialContributions: DEFAULT_INPUTS.socialContributions,
-    aanvullendPensioen: DEFAULT_INPUTS.aanvullendPensioen,
-    dienstencheques: DEFAULT_INPUTS.dienstencheques,
-    roerendeVoorheffing: DEFAULT_INPUTS.roerendeVoorheffing,
-    withheldTaxNL: DEFAULT_INPUTS.withheldTaxNL,
-  };
+  const parsed = PersistedInputsSchema.safeParse(raw);
+  return parsed.success ? { ...DEFAULT_INPUTS, ...parsed.data } : DEFAULT_INPUTS;
 }
 
 function loadInitialInputs(): TaxInputs {
@@ -196,8 +87,102 @@ function applyTheme(theme: Theme) {
 
 const THEME_CYCLE: Theme[] = ["auto", "light", "dark"];
 
+interface ResultsTabsProps {
+  inputs: TaxInputs;
+  onResetInputs: () => void;
+}
+
+function ResultsTabs({ inputs, onResetInputs }: ResultsTabsProps) {
+  const result = useMemo(() => calculate(inputs), [inputs]);
+  const comparisonResults = useMemo(
+    () =>
+      VALID_YEARS.map((year) => ({
+        year,
+        result: year === inputs.year ? result : calculate({ ...inputs, year }),
+      })),
+    [inputs, result],
+  );
+
+  return (
+    <Tab.Container defaultActiveKey="summary">
+      <Nav variant="tabs" className="mb-3">
+        <Nav.Item>
+          <Nav.Link eventKey="summary" aria-label={m.tabs_summary()}>
+            <i className="bi bi-pie-chart-fill me-1" />
+            {m.tabs_summary()}
+          </Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="nl" aria-label={m.tabs_nl()}>
+            🇳🇱 {m.tabs_nl()}
+          </Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="be" aria-label={m.tabs_be()}>
+            🇧🇪 {m.tabs_be()}
+          </Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="years" aria-label={m.tabs_year_comparison()}>
+            <i className="bi bi-bar-chart-line-fill me-1" />
+            {m.tabs_year_comparison()}
+          </Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="wfh" aria-label={m.tabs_wfh_ratio()}>
+            <i className="bi bi-house-fill me-1" />
+            {m.tabs_wfh_ratio()}
+          </Nav.Link>
+        </Nav.Item>
+      </Nav>
+
+      <Tab.Content>
+        <Tab.Pane eventKey="summary">
+          <SummaryResult result={result} onResetInputs={onResetInputs} />
+        </Tab.Pane>
+        <Tab.Pane eventKey="nl" className="bt-nl-accent">
+          <NLResult
+            result={result.nl}
+            withheldTaxNL={inputs.withheldTaxNL}
+            thirtyPercentRuling={inputs.thirtyPercentRuling}
+          />
+        </Tab.Pane>
+        <Tab.Pane eventKey="be" className="bt-be-accent">
+          <BEResult result={result.be} residentCountry={inputs.residentCountry} />
+        </Tab.Pane>
+        <Tab.Pane eventKey="years">
+          <MultiYearComparison rows={comparisonResults} activeYear={inputs.year} />
+        </Tab.Pane>
+        <Tab.Pane eventKey="wfh">
+          <WFHRatioChart inputs={inputs} />
+        </Tab.Pane>
+      </Tab.Content>
+    </Tab.Container>
+  );
+}
+
+function ResultsErrorFallback({ error }: FallbackProps) {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    <div className="p-4 text-center">
+      <i className="bi bi-exclamation-triangle-fill text-warning fs-2 mb-3 d-block" />
+      <h5>{m.results_error_title()}</h5>
+      <p className="text-muted small mb-3">{m.results_error_description()}</p>
+      <details className="text-start small text-muted">
+        <summary className="mb-1">{m.results_error_details()}</summary>
+        <pre className="border rounded p-2 small overflow-auto">{message}</pre>
+      </details>
+    </div>
+  );
+}
+
 export default function App() {
-  const [inputs, setInputs] = useState<TaxInputs>(loadInitialInputs);
+  const form = useForm({ defaultValues: loadInitialInputs() });
+  const rawValues = useStore(form.store, (s) => s.values);
+  const inputs = useMemo(() => {
+    const parsed = TaxInputSchema.safeParse(rawValues);
+    return parsed.success ? parsed.data : DEFAULT_INPUTS;
+  }, [rawValues]);
   const [locale, setCurrentLocale] = useState(getLocale());
   const [theme, setTheme] = useState<Theme>(loadTheme);
   const nextLangLabel = locale === "en" ? m.lang_nl() : m.lang_en();
@@ -213,16 +198,6 @@ export default function App() {
       return () => mq.removeEventListener("change", handler);
     }
   }, [theme]);
-
-  const result = useMemo(() => calculate(inputs), [inputs]);
-  const comparisonResults = useMemo(
-    () =>
-      VALID_YEARS.map((year) => ({
-        year,
-        result: year === inputs.year ? result : calculate({ ...inputs, year }),
-      })),
-    [inputs, result],
-  );
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(toPersistedInputs(inputs)));
@@ -250,8 +225,8 @@ export default function App() {
               const idx = THEME_CYCLE.indexOf(theme);
               setTheme(THEME_CYCLE[(idx + 1) % THEME_CYCLE.length] as Theme);
             }}
-            aria-label={`${m.theme_toggle_label()}: ${m[`theme_${theme}`]()}`}
-            title={`${m.theme_toggle_label()}: ${m[`theme_${theme}`]()} (click to cycle)`}
+            aria-label={`${m.theme_toggle_label()}: ${theme === "light" ? m.theme_light() : theme === "dark" ? m.theme_dark() : m.theme_auto()}`}
+            title={`${m.theme_toggle_label()}: ${theme === "light" ? m.theme_light() : theme === "dark" ? m.theme_dark() : m.theme_auto()} (click to cycle)`}
           >
             <i
               className={`bi ${theme === "light" ? "bi-sun-fill" : theme === "dark" ? "bi-moon-fill" : "bi-circle-half"}`}
@@ -277,65 +252,14 @@ export default function App() {
         <Row className="g-4 bt-main-row">
           {/* ── Left column: inputs ────────────────────────────── */}
           <Col lg={5}>
-            <InputPanel inputs={inputs} onChange={setInputs} />
+            <InputPanel form={form} />
           </Col>
 
           {/* ── Right column: results ──────────────────────────── */}
           <Col lg={7}>
-            <Tab.Container defaultActiveKey="summary">
-              <Nav variant="tabs" className="mb-3">
-                <Nav.Item>
-                  <Nav.Link eventKey="summary" aria-label={m.tabs_summary()}>
-                    <i className="bi bi-pie-chart-fill me-1" />
-                    {m.tabs_summary()}
-                  </Nav.Link>
-                </Nav.Item>
-                <Nav.Item>
-                  <Nav.Link eventKey="nl" aria-label={m.tabs_nl()}>
-                    🇳🇱 {m.tabs_nl()}
-                  </Nav.Link>
-                </Nav.Item>
-                <Nav.Item>
-                  <Nav.Link eventKey="be" aria-label={m.tabs_be()}>
-                    🇧🇪 {m.tabs_be()}
-                  </Nav.Link>
-                </Nav.Item>
-                <Nav.Item>
-                  <Nav.Link eventKey="years" aria-label={m.tabs_year_comparison()}>
-                    <i className="bi bi-bar-chart-line-fill me-1" />
-                    {m.tabs_year_comparison()}
-                  </Nav.Link>
-                </Nav.Item>
-                <Nav.Item>
-                  <Nav.Link eventKey="wfh" aria-label={m.tabs_wfh_ratio()}>
-                    <i className="bi bi-house-fill me-1" />
-                    {m.tabs_wfh_ratio()}
-                  </Nav.Link>
-                </Nav.Item>
-              </Nav>
-
-              <Tab.Content>
-                <Tab.Pane eventKey="summary">
-                  <SummaryResult result={result} onResetInputs={() => setInputs(DEFAULT_INPUTS)} />
-                </Tab.Pane>
-                <Tab.Pane eventKey="nl" className="bt-nl-accent">
-                  <NLResult
-                    result={result.nl}
-                    withheldTaxNL={inputs.withheldTaxNL}
-                    thirtyPercentRuling={inputs.thirtyPercentRuling}
-                  />
-                </Tab.Pane>
-                <Tab.Pane eventKey="be" className="bt-be-accent">
-                  <BEResult result={result.be} residentCountry={inputs.residentCountry} />
-                </Tab.Pane>
-                <Tab.Pane eventKey="years">
-                  <MultiYearComparison rows={comparisonResults} activeYear={inputs.year} />
-                </Tab.Pane>
-                <Tab.Pane eventKey="wfh">
-                  <WFHRatioChart inputs={inputs} />
-                </Tab.Pane>
-              </Tab.Content>
-            </Tab.Container>
+            <ErrorBoundary FallbackComponent={ResultsErrorFallback}>
+              <ResultsTabs inputs={inputs} onResetInputs={() => form.reset(DEFAULT_INPUTS)} />
+            </ErrorBoundary>
           </Col>
         </Row>
       </Container>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -185,7 +185,9 @@ function loadTheme(): Theme {
 function applyTheme(theme: Theme) {
   const effective =
     theme === "auto"
-      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? typeof window !== "undefined" &&
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches
         ? "dark"
         : "light"
       : theme;
@@ -204,7 +206,7 @@ export default function App() {
     applyTheme(theme);
     localStorage.setItem(THEME_KEY, theme);
 
-    if (theme === "auto") {
+    if (theme === "auto" && typeof window !== "undefined" && window.matchMedia) {
       const mq = window.matchMedia("(prefers-color-scheme: dark)");
       const handler = () => applyTheme("auto");
       mq.addEventListener("change", handler);
@@ -248,8 +250,8 @@ export default function App() {
               const idx = THEME_CYCLE.indexOf(theme);
               setTheme(THEME_CYCLE[(idx + 1) % THEME_CYCLE.length] as Theme);
             }}
-            aria-label={`Theme: ${theme}`}
-            title={`Theme: ${theme} (click to cycle)`}
+            aria-label={`${m.theme_toggle_label()}: ${m[`theme_${theme}`]()}`}
+            title={`${m.theme_toggle_label()}: ${m[`theme_${theme}`]()} (click to cycle)`}
           >
             <i
               className={`bi ${theme === "light" ? "bi-sun-fill" : theme === "dark" ? "bi-moon-fill" : "bi-circle-half"}`}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -246,7 +246,7 @@ export default function App() {
             className="ms-2"
             onClick={() => {
               const idx = THEME_CYCLE.indexOf(theme);
-              setTheme(THEME_CYCLE[(idx + 1) % THEME_CYCLE.length]);
+              setTheme(THEME_CYCLE[(idx + 1) % THEME_CYCLE.length] as Theme);
             }}
             aria-label={`Theme: ${theme}`}
             title={`Theme: ${theme} (click to cycle)`}

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -1,4 +1,8 @@
 import { useState } from "react";
+import { useStore } from "@tanstack/react-form";
+import clsx from "clsx";
+import type { ReactFormExtendedApi } from "@tanstack/react-form";
+import { z } from "zod";
 import { Accordion, Alert, Badge, Button, Col, Form, Row } from "react-bootstrap";
 import {
   VALID_YEARS,
@@ -10,9 +14,11 @@ import type { TaxInputs } from "../tax/types";
 import { getMaxDaysInYear, getTotalWorkdays } from "../tax/workdays";
 import * as m from "../paraglide/messages.js";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TaxFormApi = ReactFormExtendedApi<TaxInputs, any, any, any, any, any, any, any, any, any, any, any>;
+
 interface Props {
-  inputs: TaxInputs;
-  onChange: (updated: TaxInputs) => void;
+  form: TaxFormApi;
 }
 
 type BelgianDeductionKey =
@@ -21,29 +27,37 @@ type BelgianDeductionKey =
   | "dienstencheques"
   | "roerendeVoorheffing";
 
-const clampNumber = (value: string, min = 0, max = Number.POSITIVE_INFINITY) =>
-  Math.min(max, Math.max(min, Number(value) || 0));
+function fieldError(errors: unknown[]): string | undefined {
+  if (!errors.length) return undefined;
+  const msgs = errors.flatMap((e) => {
+    if (Array.isArray(e)) return e.map((i) => (i as { message?: string })?.message ?? String(i));
+    if (e && typeof e === "object" && "message" in e)
+      return [(e as { message: unknown }).message as string];
+    return [String(e)];
+  });
+  return msgs.filter(Boolean).join(" ") || undefined;
+}
 
-export default function InputPanel({ inputs, onChange }: Props) {
+export default function InputPanel({ form }: Props) {
   const [showFormulas, setShowFormulas] = useState(false);
+  const values = useStore(form.store, (s) => s.values);
 
-  function set<K extends keyof TaxInputs>(key: K, value: TaxInputs[K]) {
-    onChange({ ...inputs, [key]: value });
-  }
-
-  const totalWorkdays = getTotalWorkdays(inputs);
-  const maxWorkdaysInYear = getMaxDaysInYear(inputs.year);
-  const beFraction = totalWorkdays > 0 ? inputs.daysWorkedBE / totalWorkdays : 0;
+  const totalWorkdays = getTotalWorkdays(values);
+  const maxWorkdaysInYear = getMaxDaysInYear(values.year);
+  const beFraction = totalWorkdays > 0 ? values.daysWorkedBE / totalWorkdays : 0;
 
   const nlBarW =
-    maxWorkdaysInYear > 0 ? Math.min(100, (inputs.daysWorkedNL / maxWorkdaysInYear) * 100) : 0;
+    maxWorkdaysInYear > 0 ? Math.min(100, (values.daysWorkedNL / maxWorkdaysInYear) * 100) : 0;
   const beBarW =
     maxWorkdaysInYear > 0
-      ? Math.min(100 - nlBarW, (inputs.daysWorkedBE / maxWorkdaysInYear) * 100)
+      ? Math.min(100 - nlBarW, (values.daysWorkedBE / maxWorkdaysInYear) * 100)
       : 0;
   const otherBarW =
     maxWorkdaysInYear > 0
-      ? Math.min(100 - nlBarW - beBarW, ((inputs.daysWorkedOther ?? 0) / maxWorkdaysInYear) * 100)
+      ? Math.min(
+          100 - nlBarW - beBarW,
+          ((values.daysWorkedOther ?? 0) / maxWorkdaysInYear) * 100,
+        )
       : 0;
 
   return (
@@ -56,138 +70,200 @@ export default function InputPanel({ inputs, onChange }: Props) {
         </Accordion.Header>
         <Accordion.Body>
           <Row className="g-3">
-            <Col xs={12} sm={6}>
-              <Form.Label>{m.input_tax_year()}</Form.Label>
-              <Form.Select
-                value={inputs.year}
-                onChange={(e) => set("year", Number(e.target.value) as TaxInputs["year"])}
-              >
-                {VALID_YEARS.map((y) => (
-                  <option key={y} value={y}>
-                    {y}
-                  </option>
-                ))}
-              </Form.Select>
-            </Col>
+            <form.Field name="year">
+              {(field) => (
+                <Col xs={12} sm={6}>
+                  <Form.Label>{m.input_tax_year()}</Form.Label>
+                  <Form.Select
+                    value={field.state.value}
+                    onChange={(e) =>
+                      field.handleChange(Number(e.target.value) as TaxInputs["year"])
+                    }
+                    onBlur={field.handleBlur}
+                  >
+                    {VALID_YEARS.map((y) => (
+                      <option key={y} value={y}>
+                        {y}
+                      </option>
+                    ))}
+                  </Form.Select>
+                </Col>
+              )}
+            </form.Field>
 
             {VALID_RESIDENT_COUNTRIES.length > 1 && (
-              <Col xs={12} sm={6}>
-                <Form.Label>{m.input_resident_country()}</Form.Label>
-                <Form.Select
-                  value={inputs.residentCountry}
-                  onChange={(e) =>
-                    set("residentCountry", e.target.value as TaxInputs["residentCountry"])
-                  }
-                >
-                  {(VALID_RESIDENT_COUNTRIES as readonly string[]).includes("BE") && (
-                    <option value="BE">🇧🇪 {m.input_resident_country_be()}</option>
-                  )}
-                  {(VALID_RESIDENT_COUNTRIES as readonly string[]).includes("NL") && (
-                    <option value="NL">🇳🇱 {m.input_resident_country_nl()}</option>
-                  )}
-                </Form.Select>
-              </Col>
-            )}
-
-            {VALID_CIVIL_STATUSES.length > 1 && (
-              <Col xs={12} sm={6}>
-                <Form.Label>
-                  {m.input_civil_status()}{" "}
-                  <Badge
-                    bg="secondary"
-                    className="ms-1 fw-normal"
-                    aria-label={m.input_civil_status_not_used()}
-                  >
-                    {m.input_civil_status_not_used()}
-                  </Badge>
-                </Form.Label>
-                <Form.Select
-                  value={inputs.civilStatus}
-                  onChange={(e) => set("civilStatus", e.target.value as TaxInputs["civilStatus"])}
-                >
-                  {(VALID_CIVIL_STATUSES as readonly string[]).includes("single") && (
-                    <option value="single">{m.input_civil_status_single()}</option>
-                  )}
-                  {(VALID_CIVIL_STATUSES as readonly string[]).includes("married") && (
-                    <option value="married">{m.input_civil_status_married()}</option>
-                  )}
-                </Form.Select>
-              </Col>
-            )}
-
-            <Col xs={12} sm={6}>
-              <Form.Label>{m.input_dependents()}</Form.Label>
-              <Form.Control
-                type="number"
-                min={0}
-                max={10}
-                value={inputs.dependentChildren}
-                onChange={(e) => set("dependentChildren", clampNumber(e.target.value, 0, 10))}
-              />
-            </Col>
-
-            <Col xs={12}>
-              <Form.Check
-                id="aow-age"
-                label={m.input_below_aow_age()}
-                checked={inputs.belowAOWAge}
-                onChange={(e) => set("belowAOWAge", e.target.checked)}
-              />
-            </Col>
-
-            {inputs.residentCountry === "BE" && (
-              <>
-                {VALID_BELGIAN_REGIONS.length > 1 && (
+              <form.Field name="residentCountry">
+                {(field) => (
                   <Col xs={12} sm={6}>
-                    <Form.Label>
-                      {m.input_belgian_region()}{" "}
-                      <Badge
-                        bg="secondary"
-                        className="ms-1 fw-normal"
-                        aria-label={m.input_belgian_region_not_used()}
-                      >
-                        {m.input_belgian_region_not_used()}
-                      </Badge>
-                    </Form.Label>
+                    <Form.Label>{m.input_resident_country()}</Form.Label>
                     <Form.Select
-                      value={inputs.belgianRegion}
+                      value={field.state.value}
                       onChange={(e) =>
-                        set("belgianRegion", e.target.value as TaxInputs["belgianRegion"])
+                        field.handleChange(e.target.value as TaxInputs["residentCountry"])
                       }
+                      onBlur={field.handleBlur}
                     >
-                      {(VALID_BELGIAN_REGIONS as readonly string[]).includes("flemish") && (
-                        <option value="flemish">{m.input_belgian_region_flemish()}</option>
+                      {(VALID_RESIDENT_COUNTRIES as readonly string[]).includes("BE") && (
+                        <option value="BE">🇧🇪 {m.input_resident_country_be()}</option>
                       )}
-                      {(VALID_BELGIAN_REGIONS as readonly string[]).includes("walloon") && (
-                        <option value="walloon">{m.input_belgian_region_walloon()}</option>
-                      )}
-                      {(VALID_BELGIAN_REGIONS as readonly string[]).includes("brussels") && (
-                        <option value="brussels">{m.input_belgian_region_brussels()}</option>
+                      {(VALID_RESIDENT_COUNTRIES as readonly string[]).includes("NL") && (
+                        <option value="NL">🇳🇱 {m.input_resident_country_nl()}</option>
                       )}
                     </Form.Select>
                   </Col>
                 )}
+              </form.Field>
+            )}
 
-                <Col xs={12} sm={6}>
-                  <Form.Label>
-                    {m.input_municipal_tax()}{" "}
-                    <Badge bg="secondary" className="ms-1">
-                      %
-                    </Badge>
-                  </Form.Label>
-                  <Form.Control
-                    type="number"
-                    min={0}
-                    max={15}
-                    step={0.1}
-                    value={inputs.communalTaxRate}
-                    onChange={(e) => set("communalTaxRate", clampNumber(e.target.value, 0, 15))}
-                    aria-describedby="communal-tax-hint"
+            {VALID_CIVIL_STATUSES.length > 1 && (
+              <form.Field name="civilStatus">
+                {(field) => (
+                  <Col xs={12} sm={6}>
+                    <Form.Label>
+                      {m.input_civil_status()}{" "}
+                      <Badge
+                        bg="secondary"
+                        className="ms-1 fw-normal"
+                        aria-label={m.input_civil_status_not_used()}
+                      >
+                        {m.input_civil_status_not_used()}
+                      </Badge>
+                    </Form.Label>
+                    <Form.Select
+                      value={field.state.value}
+                      onChange={(e) =>
+                        field.handleChange(e.target.value as TaxInputs["civilStatus"])
+                      }
+                      onBlur={field.handleBlur}
+                    >
+                      {(VALID_CIVIL_STATUSES as readonly string[]).includes("single") && (
+                        <option value="single">{m.input_civil_status_single()}</option>
+                      )}
+                      {(VALID_CIVIL_STATUSES as readonly string[]).includes("married") && (
+                        <option value="married">{m.input_civil_status_married()}</option>
+                      )}
+                    </Form.Select>
+                  </Col>
+                )}
+              </form.Field>
+            )}
+
+            <form.Field
+              name="dependentChildren"
+              validators={{ onChange: z.number().int().min(0).max(10) }}
+            >
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12} sm={6}>
+                    <Form.Label>{m.input_dependents()}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min={0}
+                      max={10}
+                      value={field.state.value}
+                      onChange={(e) => {
+                        const n = (e.target as HTMLInputElement).valueAsNumber;
+                        field.handleChange(Number.isNaN(n) ? 0 : n);
+                      }}
+                      onBlur={field.handleBlur}
+                      isInvalid={!!err}
+                    />
+                    {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                  </Col>
+                );
+              }}
+            </form.Field>
+
+            <form.Field name="belowAOWAge">
+              {(field) => (
+                <Col xs={12}>
+                  <Form.Check
+                    id="aow-age"
+                    label={m.input_below_aow_age()}
+                    checked={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.checked)}
                   />
-                  <Form.Text id="communal-tax-hint" className="text-muted">
-                    {m.input_municipal_tax_hint()}
-                  </Form.Text>
                 </Col>
+              )}
+            </form.Field>
+
+            {values.residentCountry === "BE" && (
+              <>
+                {VALID_BELGIAN_REGIONS.length > 1 && (
+                  <form.Field name="belgianRegion">
+                    {(field) => (
+                      <Col xs={12} sm={6}>
+                        <Form.Label>
+                          {m.input_belgian_region()}{" "}
+                          <Badge
+                            bg="secondary"
+                            className="ms-1 fw-normal"
+                            aria-label={m.input_belgian_region_not_used()}
+                          >
+                            {m.input_belgian_region_not_used()}
+                          </Badge>
+                        </Form.Label>
+                        <Form.Select
+                          value={field.state.value}
+                          onChange={(e) =>
+                            field.handleChange(e.target.value as TaxInputs["belgianRegion"])
+                          }
+                          onBlur={field.handleBlur}
+                        >
+                          {(VALID_BELGIAN_REGIONS as readonly string[]).includes("flemish") && (
+                            <option value="flemish">{m.input_belgian_region_flemish()}</option>
+                          )}
+                          {(VALID_BELGIAN_REGIONS as readonly string[]).includes("walloon") && (
+                            <option value="walloon">{m.input_belgian_region_walloon()}</option>
+                          )}
+                          {(VALID_BELGIAN_REGIONS as readonly string[]).includes("brussels") && (
+                            <option value="brussels">{m.input_belgian_region_brussels()}</option>
+                          )}
+                        </Form.Select>
+                      </Col>
+                    )}
+                  </form.Field>
+                )}
+
+                <form.Field
+                  name="communalTaxRate"
+                  validators={{ onChange: z.number().min(0).max(15) }}
+                >
+                  {(field) => {
+                    const err = fieldError(field.state.meta.errors as unknown[]);
+                    return (
+                      <Col xs={12} sm={6}>
+                        <Form.Label>
+                          {m.input_municipal_tax()}{" "}
+                          <Badge bg="secondary" className="ms-1">
+                            %
+                          </Badge>
+                        </Form.Label>
+                        <Form.Control
+                          type="number"
+                          min={0}
+                          max={15}
+                          step={0.1}
+                          value={field.state.value}
+                          onChange={(e) => {
+                            const n = (e.target as HTMLInputElement).valueAsNumber;
+                            field.handleChange(Number.isNaN(n) ? 0 : n);
+                          }}
+                          onBlur={field.handleBlur}
+                          isInvalid={!!err}
+                          aria-describedby="communal-tax-hint"
+                        />
+                        <Form.Text id="communal-tax-hint" className="text-muted">
+                          {m.input_municipal_tax_hint()}
+                        </Form.Text>
+                        {err && (
+                          <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>
+                        )}
+                      </Col>
+                    );
+                  }}
+                </form.Field>
               </>
             )}
           </Row>
@@ -202,97 +278,157 @@ export default function InputPanel({ inputs, onChange }: Props) {
         </Accordion.Header>
         <Accordion.Body>
           <Row className="g-3">
-            <Col xs={12}>
-              <Form.Label>{m.input_gross_salary()}</Form.Label>
-              <Form.Control
-                type="number"
-                min={0}
-                step={100}
-                value={inputs.grossSalary}
-                onChange={(e) => set("grossSalary", clampNumber(e.target.value))}
-                aria-describedby="gross-salary-hint"
-              />
-              <Form.Text id="gross-salary-hint" className="text-muted">
-                {m.input_gross_salary_hint()}
-              </Form.Text>
-            </Col>
+            <form.Field name="grossSalary" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12}>
+                    <Form.Label>{m.input_gross_salary()}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min={0}
+                      step={100}
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                      onBlur={field.handleBlur}
+                      isInvalid={!!err}
+                      aria-describedby="gross-salary-hint"
+                    />
+                    <Form.Text id="gross-salary-hint" className="text-muted">
+                      {m.input_gross_salary_hint()}
+                    </Form.Text>
+                    {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                  </Col>
+                );
+              }}
+            </form.Field>
 
-            <Col xs={12}>
-              <Form.Group controlId="withheldTaxNL">
-                <Form.Label>{m.input_withheld_tax_nl()}</Form.Label>
-                <Form.Control
-                  type="number"
-                  min={0}
-                  step={100}
-                  value={inputs.withheldTaxNL ?? 0}
-                  onChange={(e) => set("withheldTaxNL", clampNumber(e.target.value))}
-                  aria-describedby="withheld-tax-nl-hint"
-                />
-                <Form.Text id="withheld-tax-nl-hint" className="text-muted">
-                  {m.input_withheld_tax_nl_hint()}
-                </Form.Text>
-              </Form.Group>
-            </Col>
+            <form.Field name="withheldTaxNL" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12}>
+                    <Form.Group controlId="withheldTaxNL">
+                      <Form.Label>{m.input_withheld_tax_nl()}</Form.Label>
+                      <Form.Control
+                        type="number"
+                        min={0}
+                        step={100}
+                        value={field.state.value}
+                        onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                        onBlur={field.handleBlur}
+                        isInvalid={!!err}
+                        aria-describedby="withheld-tax-nl-hint"
+                      />
+                      <Form.Text id="withheld-tax-nl-hint" className="text-muted">
+                        {m.input_withheld_tax_nl_hint()}
+                      </Form.Text>
+                      {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                    </Form.Group>
+                  </Col>
+                );
+              }}
+            </form.Field>
 
-            <Col xs={12} sm={6}>
-              <Form.Label>{m.input_workdays_nl()}</Form.Label>
-              <Form.Control
-                type="number"
-                min={0}
-                value={inputs.daysWorkedNL}
-                onChange={(e) => set("daysWorkedNL", clampNumber(e.target.value))}
-                aria-describedby="workdays-nl-hint"
-              />
-              <Form.Text id="workdays-nl-hint" className="text-muted">
-                {m.input_workdays_nl_hint()}
-              </Form.Text>
-            </Col>
+            <form.Field name="daysWorkedNL" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12} sm={6}>
+                    <Form.Label>{m.input_workdays_nl()}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min={0}
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                      onBlur={field.handleBlur}
+                      isInvalid={!!err}
+                      aria-describedby="workdays-nl-hint"
+                    />
+                    <Form.Text id="workdays-nl-hint" className="text-muted">
+                      {m.input_workdays_nl_hint()}
+                    </Form.Text>
+                    {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                  </Col>
+                );
+              }}
+            </form.Field>
 
-            <Col xs={12} sm={6}>
-              <Form.Label>{m.input_workdays_be()}</Form.Label>
-              <Form.Control
-                type="number"
-                min={0}
-                value={inputs.daysWorkedBE}
-                onChange={(e) => set("daysWorkedBE", clampNumber(e.target.value))}
-              />
-            </Col>
+            <form.Field name="daysWorkedBE" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12} sm={6}>
+                    <Form.Label>{m.input_workdays_be()}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min={0}
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                      onBlur={field.handleBlur}
+                      isInvalid={!!err}
+                    />
+                    {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                  </Col>
+                );
+              }}
+            </form.Field>
 
-            <Col xs={12} sm={6}>
-              <Form.Group controlId="daysWorkedOther">
-                <Form.Label>{m.input_workdays_other()}</Form.Label>
-                <Form.Control
-                  type="number"
-                  min={0}
-                  value={inputs.daysWorkedOther ?? 0}
-                  onChange={(e) => set("daysWorkedOther", clampNumber(e.target.value))}
-                  aria-describedby="days-other-hint"
-                />
-                <Form.Text id="days-other-hint" className="text-muted">
-                  {m.input_workdays_other_hint()}
-                </Form.Text>
-              </Form.Group>
-            </Col>
+            <form.Field name="daysWorkedOther" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12} sm={6}>
+                    <Form.Group controlId="daysWorkedOther">
+                      <Form.Label>{m.input_workdays_other()}</Form.Label>
+                      <Form.Control
+                        type="number"
+                        min={0}
+                        value={field.state.value}
+                        onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                        onBlur={field.handleBlur}
+                        isInvalid={!!err}
+                        aria-describedby="days-other-hint"
+                      />
+                      <Form.Text id="days-other-hint" className="text-muted">
+                        {m.input_workdays_other_hint()}
+                      </Form.Text>
+                      {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                    </Form.Group>
+                  </Col>
+                );
+              }}
+            </form.Field>
 
-            <Col xs={12} sm={6}>
-              <Form.Group controlId="sickDays">
-                <Form.Label>{m.input_sick_days()}</Form.Label>
-                <Form.Control
-                  type="number"
-                  min={0}
-                  value={inputs.sickDays ?? 0}
-                  onChange={(e) => set("sickDays", clampNumber(e.target.value))}
-                  aria-describedby="sick-days-hint"
-                />
-                <Form.Text id="sick-days-hint" className="text-muted">
-                  {m.input_sick_days_hint()}
-                </Form.Text>
-              </Form.Group>
-            </Col>
+            <form.Field name="sickDays" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12} sm={6}>
+                    <Form.Group controlId="sickDays">
+                      <Form.Label>{m.input_sick_days()}</Form.Label>
+                      <Form.Control
+                        type="number"
+                        min={0}
+                        value={field.state.value}
+                        onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                        onBlur={field.handleBlur}
+                        isInvalid={!!err}
+                        aria-describedby="sick-days-hint"
+                      />
+                      <Form.Text id="sick-days-hint" className="text-muted">
+                        {m.input_sick_days_hint()}
+                      </Form.Text>
+                      {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                    </Form.Group>
+                  </Col>
+                );
+              }}
+            </form.Field>
 
             <Col xs={12}>
               <div
-                className={`bt-workday-bar${totalWorkdays > maxWorkdaysInYear ? " bt-workday-bar--over" : ""}`}
+                className={clsx("bt-workday-bar", totalWorkdays > maxWorkdaysInYear && "bt-workday-bar--over")}
                 role="img"
                 aria-label={`${m.input_workdays_total()} ${totalWorkdays}`}
               >
@@ -302,7 +438,7 @@ export default function InputPanel({ inputs, onChange }: Props) {
                     style={{ width: `${nlBarW}%` }}
                   >
                     {nlBarW > 14 && (
-                      <span className="bt-workday-bar__label">{inputs.daysWorkedNL}</span>
+                      <span className="bt-workday-bar__label">{values.daysWorkedNL}</span>
                     )}
                   </div>
                 )}
@@ -312,7 +448,7 @@ export default function InputPanel({ inputs, onChange }: Props) {
                     style={{ width: `${beBarW}%` }}
                   >
                     {beBarW > 10 && (
-                      <span className="bt-workday-bar__label">{inputs.daysWorkedBE}</span>
+                      <span className="bt-workday-bar__label">{values.daysWorkedBE}</span>
                     )}
                   </div>
                 )}
@@ -325,11 +461,11 @@ export default function InputPanel({ inputs, onChange }: Props) {
               </div>
               <Form.Text
                 role="status"
-                className={
+                className={clsx(
                   totalWorkdays === 0 || totalWorkdays > maxWorkdaysInYear
                     ? "text-warning"
-                    : "text-muted"
-                }
+                    : "text-muted",
+                )}
               >
                 {m.input_workdays_total()} {totalWorkdays}
                 {totalWorkdays === 0 && ` — ${m.input_workdays_total_zero_warning()}`}
@@ -338,12 +474,12 @@ export default function InputPanel({ inputs, onChange }: Props) {
               <Form.Text className="text-muted d-block mt-1">
                 {m.input_workdays_typical()}
               </Form.Text>
-              {inputs.residentCountry === "BE" && totalWorkdays > 0 && beFraction >= 0.5 && (
+              {values.residentCountry === "BE" && totalWorkdays > 0 && beFraction >= 0.5 && (
                 <Alert variant="warning" className="mt-2 py-2 small mb-0">
                   {m.input_social_security_above_50()}
                 </Alert>
               )}
-              {inputs.residentCountry === "BE" &&
+              {values.residentCountry === "BE" &&
                 totalWorkdays > 0 &&
                 beFraction >= 0.25 &&
                 beFraction < 0.5 && (
@@ -353,20 +489,24 @@ export default function InputPanel({ inputs, onChange }: Props) {
                 )}
             </Col>
 
-            <Col xs={12}>
-              <Form.Check
-                id="thirty-ruling"
-                label={m.input_thirty_percent_ruling()}
-                checked={inputs.thirtyPercentRuling}
-                onChange={(e) => set("thirtyPercentRuling", e.target.checked)}
-                aria-describedby="thirty-ruling-hint"
-              />
-              <Form.Text id="thirty-ruling-hint" className="text-muted">
-                {m.input_thirty_percent_ruling_hint()}
-              </Form.Text>
-            </Col>
+            <form.Field name="thirtyPercentRuling">
+              {(field) => (
+                <Col xs={12}>
+                  <Form.Check
+                    id="thirty-ruling"
+                    label={m.input_thirty_percent_ruling()}
+                    checked={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.checked)}
+                    aria-describedby="thirty-ruling-hint"
+                  />
+                  <Form.Text id="thirty-ruling-hint" className="text-muted">
+                    {m.input_thirty_percent_ruling_hint()}
+                  </Form.Text>
+                </Col>
+              )}
+            </form.Field>
 
-            {inputs.residentCountry === "BE" && (
+            {values.residentCountry === "BE" && (
               <>
                 {(
                   [
@@ -387,24 +527,35 @@ export default function InputPanel({ inputs, onChange }: Props) {
                       label: m.input_roerende_voorheffing(),
                     },
                   ] as const satisfies readonly { key: BelgianDeductionKey; label: string }[]
-                ).map((field) => (
-                  <Col key={field.key} xs={12} sm={6}>
-                    <Form.Group controlId={field.key}>
-                      <Form.Label>{field.label}</Form.Label>
-                      <Form.Control
-                        type="number"
-                        min={0}
-                        step={100}
-                        value={inputs[field.key] ?? 0}
-                        onChange={(e) =>
-                          set(
-                            field.key,
-                            clampNumber(e.target.value) as TaxInputs[BelgianDeductionKey],
-                          )
-                        }
-                      />
-                    </Form.Group>
-                  </Col>
+                ).map((fieldDef) => (
+                  <form.Field
+                    key={fieldDef.key}
+                    name={fieldDef.key}
+                    validators={{ onChange: z.number().min(0) }}
+                  >
+                    {(field) => {
+                      const err = fieldError(field.state.meta.errors as unknown[]);
+                      return (
+                        <Col xs={12} sm={6}>
+                          <Form.Group controlId={fieldDef.key}>
+                            <Form.Label>{fieldDef.label}</Form.Label>
+                            <Form.Control
+                              type="number"
+                              min={0}
+                              step={100}
+                              value={field.state.value}
+                              onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                              onBlur={field.handleBlur}
+                              isInvalid={!!err}
+                            />
+                            {err && (
+                              <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>
+                            )}
+                          </Form.Group>
+                        </Col>
+                      );
+                    }}
+                  </form.Field>
                 ))}
               </>
             )}

--- a/src/components/MultiYearComparison.tsx
+++ b/src/components/MultiYearComparison.tsx
@@ -1,4 +1,5 @@
 import { Badge, Table } from "react-bootstrap";
+import clsx from "clsx";
 import { VALID_YEARS } from "../tax/constants";
 import type { TaxYear } from "../tax/constants";
 import type { TaxResult } from "../tax/types";
@@ -33,7 +34,7 @@ export default function MultiYearComparison({ rows, activeYear }: Props) {
           return (
             <div
               key={year}
-              className={`bt-year-chart__row${isActive ? " bt-year-chart__row--active" : ""}`}
+              className={clsx("bt-year-chart__row", isActive && "bt-year-chart__row--active")}
             >
               <div className="bt-year-chart__label">
                 {year}
@@ -92,7 +93,7 @@ export default function MultiYearComparison({ rows, activeYear }: Props) {
         </thead>
         <tbody>
           {rows.map(({ year, result }) => (
-            <tr key={year} className={year === activeYear ? "table-primary" : undefined}>
+            <tr key={year} className={clsx(year === activeYear && "table-primary")}>
               <td>
                 {year} {year === activeYear && <Badge bg="primary">{m.years_active()}</Badge>}
               </td>

--- a/src/components/NLResult.tsx
+++ b/src/components/NLResult.tsx
@@ -1,4 +1,5 @@
 import { Badge, Table } from "react-bootstrap";
+import clsx from "clsx";
 import type { NLTaxResult } from "../tax/types";
 import * as m from "../paraglide/messages.js";
 import { fmtExact as fmt, pctExact as pct } from "./format.js";
@@ -110,9 +111,9 @@ export default function NLResult({
                 <td>{m.nl_withheld()}</td>
                 <td className="text-end">{fmt(withheldTaxNL)}</td>
               </tr>
-              <tr className={`fw-bold ${nlBalance >= 0 ? "table-success" : "table-danger"}`}>
+              <tr className={clsx("fw-bold", nlBalance >= 0 ? "table-success" : "table-danger")}>
                 <td>{nlBalance >= 0 ? m.nl_balance_refund() : m.nl_balance_due()}</td>
-                <td className={`text-end ${nlBalance >= 0 ? "text-success" : "text-danger"}`}>
+                <td className={clsx("text-end", nlBalance >= 0 ? "text-success" : "text-danger")}>
                   {nlBalance >= 0 ? "+" : "−"}
                   {fmt(Math.abs(nlBalance))}
                 </td>

--- a/src/components/SummaryResult.tsx
+++ b/src/components/SummaryResult.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Alert, Button, Col, Row, Stack } from "react-bootstrap";
+import clsx from "clsx";
 import type { TaxResult } from "../tax/types";
 import { getTotalWorkdays } from "../tax/workdays";
 import * as m from "../paraglide/messages.js";
@@ -267,13 +268,13 @@ export default function SummaryResult({ result, onResetInputs }: Props) {
               <span className="bt-breakdown__value text-danger">−{fmt(nl.netTaxNL)}</span>
             </div>
             <div
-              className={`bt-breakdown__row ${nlBalance >= 0 ? "bt-breakdown__row--ok" : "bt-breakdown__row--warn"}`}
+              className={clsx("bt-breakdown__row", nlBalance >= 0 ? "bt-breakdown__row--ok" : "bt-breakdown__row--warn")}
             >
               <span className="bt-breakdown__label bt-breakdown__label--strong">
                 🇳🇱 {m.summary_nl_balance()}
               </span>
               <span
-                className={`bt-breakdown__value bt-breakdown__label--strong ${nlBalance >= 0 ? "text-success" : "text-danger"}`}
+                className={clsx("bt-breakdown__value", "bt-breakdown__label--strong", nlBalance >= 0 ? "text-success" : "text-danger")}
               >
                 {fmtSigned(nlBalance)}
               </span>
@@ -287,7 +288,7 @@ export default function SummaryResult({ result, onResetInputs }: Props) {
           </div>
 
           <div
-            className={`bt-balance ${netResult >= 0 ? "bt-balance--refund" : "bt-balance--owe"}`}
+            className={clsx("bt-balance", netResult >= 0 ? "bt-balance--refund" : "bt-balance--owe")}
           >
             <div className="bt-balance__label">
               <i

--- a/src/components/WFHRatioChart.tsx
+++ b/src/components/WFHRatioChart.tsx
@@ -1,5 +1,19 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { Badge, Table } from "react-bootstrap";
+import clsx from "clsx";
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ReferenceArea,
+  ReferenceDot,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import { calculate } from "../tax";
 import type { TaxInputs } from "../tax/types";
 import * as m from "../paraglide/messages.js";
@@ -10,6 +24,7 @@ interface Props {
 }
 
 interface DataPoint {
+  x: number; // beRatio * 100 (0–100)
   beRatio: number;
   beDays: number;
   nlDays: number;
@@ -27,12 +42,6 @@ const T_25 = 0.25;
 /** ≤49 % BE → Dutch social security remains applicable via kaderakkoord (apply at SVB; A1 document required) */
 const T_49 = 0.49;
 
-const W = 600;
-const H = 300;
-const PAD = { top: 32, right: 24, bottom: 52, left: 76 };
-const CW = W - PAD.left - PAD.right;
-const CH = H - PAD.top - PAD.bottom;
-
 function fmtK(n: number): string {
   if (Math.abs(n) >= 1000) return `€${Math.round(n / 1000)}k`;
   return `€${Math.round(n)}`;
@@ -47,10 +56,40 @@ function getZone(ratio: number): Zone {
   return "above";
 }
 
+interface ThresholdLabelProps {
+  x?: number;
+  viewBox?: { y: number };
+  label: string;
+  color: string;
+  bg: string;
+}
+
+function ThresholdLabel({ x, viewBox, label, color, bg }: ThresholdLabelProps) {
+  if (x == null || !viewBox) return null;
+  const W = 44;
+  const H = 14;
+  return (
+    <g transform={`translate(${x + 4}, ${viewBox.y + 4})`}>
+      <rect rx={3} ry={3} width={W} height={H} fill={bg} />
+      <text
+        x={W / 2}
+        y={H / 2}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize={8}
+        fontFamily="var(--bt-font-mono)"
+        fontWeight={600}
+        fill={color}
+      >
+        {label}
+      </text>
+    </g>
+  );
+}
+
 export default function WFHRatioChart({ inputs }: Props) {
   const [hovered, setHovered] = useState<number | null>(null);
   const [tableOpen, setTableOpen] = useState(false);
-  const svgRef = useRef<SVGSVGElement>(null);
 
   const nlbeDays = inputs.daysWorkedNL + inputs.daysWorkedBE;
 
@@ -65,6 +104,7 @@ export default function WFHRatioChart({ inputs }: Props) {
         daysWorkedBE: beDays,
       });
       return {
+        x: i,
         beRatio,
         beDays,
         nlDays: nlbeDays - beDays,
@@ -96,27 +136,6 @@ export default function WFHRatioChart({ inputs }: Props) {
   const yLow = yMin - yPad;
   const yHigh = yMax + yPad;
 
-  const xOf = (r: number) => PAD.left + r * CW;
-  const xIdx = (i: number) => xOf(i / (STEPS - 1));
-  const yOf = (v: number) => PAD.top + CH - ((v - yLow) / (yHigh - yLow)) * CH;
-
-  const polyline = (key: keyof DataPoint) =>
-    data
-      .map(
-        (d, i) => `${i === 0 ? "M" : "L"}${xIdx(i).toFixed(1)},${yOf(d[key] as number).toFixed(1)}`,
-      )
-      .join(" ");
-
-  const areaPath = data.length
-    ? `${polyline("netIncome")} L${xIdx(STEPS - 1).toFixed(1)},${(PAD.top + CH).toFixed(1)} L${xIdx(0).toFixed(1)},${(PAD.top + CH).toFixed(1)} Z`
-    : "";
-
-  const Y_TICKS = 5;
-  const yTicks = Array.from(
-    { length: Y_TICKS + 1 },
-    (_, i) => yLow + (i / Y_TICKS) * (yHigh - yLow),
-  );
-
   const showBE = inputs.residentCountry === "BE";
   const hp = hovered !== null ? (data[hovered] ?? null) : null;
   const displayPoint = hp ?? data[currentIdx] ?? null;
@@ -126,48 +145,6 @@ export default function WFHRatioChart({ inputs }: Props) {
   const optimalNet = data[optimalIdx]?.netIncome ?? 0;
   const delta = optimalNet - currentNet;
   const currentZone = getZone(currentBeRatio);
-
-  const x90 = xOf(T_90);
-  const x25 = xOf(T_25);
-  const x49 = xOf(T_49);
-  const xCur = xIdx(currentIdx);
-  const xOpt = xIdx(optimalIdx);
-
-  // Unified pointer handler — shared by mouse and touch
-  function scrubTo(clientX: number) {
-    const rect = svgRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const idx = Math.round(
-      (((clientX - rect.left) * (W / rect.width) - PAD.left) / CW) * (STEPS - 1),
-    );
-    setHovered(Math.max(0, Math.min(STEPS - 1, idx)));
-  }
-
-  function handleMouseMove(e: React.MouseEvent<SVGSVGElement>) {
-    scrubTo(e.clientX);
-  }
-
-  // Attach touch listener non-passively so preventDefault() suppresses scroll
-  useEffect(() => {
-    const el = svgRef.current;
-    if (!el) return;
-    function onTouchMove(e: TouchEvent) {
-      e.preventDefault();
-      const touch = e.touches[0];
-      if (touch) scrubTo(touch.clientX);
-    }
-    function onTouchEnd() {
-      setHovered(null);
-    }
-    el.addEventListener("touchmove", onTouchMove, { passive: false });
-    el.addEventListener("touchend", onTouchEnd);
-    return () => {
-      el.removeEventListener("touchmove", onTouchMove);
-      el.removeEventListener("touchend", onTouchEnd);
-    };
-    // scrubTo reads svgRef which is stable; eslint-disable not needed here
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   if (nlbeDays === 0) {
     return (
@@ -199,291 +176,240 @@ export default function WFHRatioChart({ inputs }: Props) {
 
       {/* ── Chart ───────────────────────────────────────────────────── */}
       <div className="bt-wfh-chart-wrap">
-        <svg
-          ref={svgRef}
-          viewBox={`0 0 ${W} ${H}`}
-          className="bt-wfh-svg"
-          onMouseMove={handleMouseMove}
-          onMouseLeave={() => setHovered(null)}
-          aria-label={m.wfh_title()}
-        >
-          <defs>
-            <linearGradient id="wfh-net-grad" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="var(--bt-success)" stopOpacity="0.18" />
-              <stop offset="100%" stopColor="var(--bt-success)" stopOpacity="0.01" />
-            </linearGradient>
-            <filter id="wfh-glow" x="-20%" y="-50%" width="140%" height="200%">
-              <feGaussianBlur stdDeviation="2.5" result="blur" />
-              <feMerge>
-                <feMergeNode in="blur" />
-                <feMergeNode in="SourceGraphic" />
-              </feMerge>
-            </filter>
-            <clipPath id="wfh-clip">
-              <rect x={PAD.left} y={PAD.top} width={CW} height={CH} />
-            </clipPath>
-          </defs>
-
-          {/* ── Zone backgrounds ──────────────────────────────────────── */}
-          <rect
-            x={PAD.left}
-            y={PAD.top}
-            width={x90 - PAD.left}
-            height={CH}
-            className="bt-wfh-zone bt-wfh-zone--full"
-          />
-          <rect
-            x={x90}
-            y={PAD.top}
-            width={x25 - x90}
-            height={CH}
-            className="bt-wfh-zone bt-wfh-zone--hybrid"
-          />
-          <rect
-            x={x25}
-            y={PAD.top}
-            width={x49 - x25}
-            height={CH}
-            className="bt-wfh-zone bt-wfh-zone--kaderakkoord"
-          />
-          <rect
-            x={x49}
-            y={PAD.top}
-            width={W - PAD.right - x49}
-            height={CH}
-            className="bt-wfh-zone bt-wfh-zone--above"
-          />
-
-          {/* Zone top-edge accents */}
-          <line
-            x1={PAD.left}
-            x2={x90}
-            y1={PAD.top}
-            y2={PAD.top}
-            className="bt-wfh-zone-edge bt-wfh-zone-edge--full"
-          />
-          <line
-            x1={x90}
-            x2={x25}
-            y1={PAD.top}
-            y2={PAD.top}
-            className="bt-wfh-zone-edge bt-wfh-zone-edge--hybrid"
-          />
-          <line
-            x1={x25}
-            x2={x49}
-            y1={PAD.top}
-            y2={PAD.top}
-            className="bt-wfh-zone-edge bt-wfh-zone-edge--kaderakkoord"
-          />
-          <line
-            x1={x49}
-            x2={W - PAD.right}
-            y1={PAD.top}
-            y2={PAD.top}
-            className="bt-wfh-zone-edge bt-wfh-zone-edge--above"
-          />
-
-          {/* ── Y grid + labels ───────────────────────────────────────── */}
-          {yTicks.map((v, i) => (
-            <g key={i}>
-              <line
-                x1={PAD.left}
-                x2={W - PAD.right}
-                y1={yOf(v)}
-                y2={yOf(v)}
-                className="bt-wfh-grid"
-              />
-              <text
-                x={PAD.left - 8}
-                y={yOf(v)}
-                textAnchor="end"
-                dominantBaseline="middle"
-                className="bt-wfh-axis-label"
-              >
-                {fmtK(v)}
-              </text>
-            </g>
-          ))}
-
-          {/* ── X axis ────────────────────────────────────────────────── */}
-          {[0, 10, 25, 50, 75, 100].map((p) => (
-            <text
-              key={p}
-              x={xOf(p / 100)}
-              y={H - PAD.bottom + 16}
-              textAnchor="middle"
-              className="bt-wfh-axis-label"
+        <div className="bt-wfh-recharts">
+          <ResponsiveContainer width="100%" height={300}>
+            <ComposedChart
+              data={data}
+              margin={{ top: 16, right: 16, bottom: 32, left: 56 }}
+              onMouseMove={(state) => {
+                if (state?.isTooltipActive && typeof state?.activeTooltipIndex === "number") {
+                  setHovered(state.activeTooltipIndex);
+                }
+              }}
+              onMouseLeave={() => setHovered(null)}
             >
-              {p}%
-            </text>
-          ))}
-          <text x={PAD.left + CW / 2} y={H - 6} textAnchor="middle" className="bt-wfh-axis-title">
-            {m.wfh_x_label()}
-          </text>
+              <defs>
+                <linearGradient id="wfh-net-grad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="var(--bt-success)" stopOpacity={0.18} />
+                  <stop offset="100%" stopColor="var(--bt-success)" stopOpacity={0.01} />
+                </linearGradient>
+              </defs>
 
-          {/* ── Threshold lines + chips ────────────────────────────────── */}
-          <line
-            x1={x90}
-            x2={x90}
-            y1={PAD.top}
-            y2={H - PAD.bottom}
-            className="bt-wfh-threshold bt-wfh-threshold--10"
-          />
-          <line
-            x1={x25}
-            x2={x25}
-            y1={PAD.top}
-            y2={H - PAD.bottom}
-            className="bt-wfh-threshold bt-wfh-threshold--25"
-          />
-          <line
-            x1={x49}
-            x2={x49}
-            y1={PAD.top}
-            y2={H - PAD.bottom}
-            className="bt-wfh-threshold bt-wfh-threshold--49"
-          />
+              {/* Zone shading */}
+              <ReferenceArea x1={0} x2={T_90 * 100} fill="rgba(34,197,94,0.06)" stroke="none" />
+              <ReferenceArea
+                x1={T_90 * 100}
+                x2={T_25 * 100}
+                fill="rgba(96,165,250,0.025)"
+                stroke="none"
+              />
+              <ReferenceArea
+                x1={T_25 * 100}
+                x2={T_49 * 100}
+                fill="rgba(168,85,247,0.025)"
+                stroke="none"
+              />
+              <ReferenceArea x1={T_49 * 100} x2={100} fill="rgba(245,158,11,0.025)" stroke="none" />
 
-          <g transform={`translate(${x90 + 4}, ${PAD.top + 4})`}>
-            <rect
-              rx="3"
-              ry="3"
-              width="44"
-              height="14"
-              className="bt-wfh-chip-bg bt-wfh-chip-bg--10"
-            />
-            <text
-              x="22"
-              y="7"
-              textAnchor="middle"
-              dominantBaseline="middle"
-              className="bt-wfh-chip-text bt-wfh-chip-text--10"
-            >
-              {m.wfh_threshold_10_label()}
-            </text>
-          </g>
-          <g transform={`translate(${x25 + 4}, ${PAD.top + 4})`}>
-            <rect
-              rx="3"
-              ry="3"
-              width="44"
-              height="14"
-              className="bt-wfh-chip-bg bt-wfh-chip-bg--25"
-            />
-            <text
-              x="22"
-              y="7"
-              textAnchor="middle"
-              dominantBaseline="middle"
-              className="bt-wfh-chip-text bt-wfh-chip-text--25"
-            >
-              {m.wfh_threshold_25_label()}
-            </text>
-          </g>
-          <g transform={`translate(${x49 + 4}, ${PAD.top + 4})`}>
-            <rect
-              rx="3"
-              ry="3"
-              width="44"
-              height="14"
-              className="bt-wfh-chip-bg bt-wfh-chip-bg--49"
-            />
-            <text
-              x="22"
-              y="7"
-              textAnchor="middle"
-              dominantBaseline="middle"
-              className="bt-wfh-chip-text bt-wfh-chip-text--49"
-            >
-              {m.wfh_threshold_49_label()}
-            </text>
-          </g>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="var(--bt-border-soft)"
+                vertical={false}
+              />
 
-          {/* ── Area fill + data lines ─────────────────────────────────── */}
-          <g clipPath="url(#wfh-clip)">
-            <path d={areaPath} fill="url(#wfh-net-grad)" />
-            <path
-              d={polyline("netIncome")}
-              fill="none"
-              className="bt-wfh-line bt-wfh-line--net"
-              filter="url(#wfh-glow)"
-            />
-            <path d={polyline("nlTax")} fill="none" className="bt-wfh-line bt-wfh-line--nl" />
-            {showBE && (
-              <path d={polyline("beTax")} fill="none" className="bt-wfh-line bt-wfh-line--be" />
-            )}
-          </g>
+              <XAxis
+                dataKey="x"
+                type="number"
+                domain={[0, 100]}
+                ticks={[0, 10, 25, 50, 75, 100]}
+                tickFormatter={(v: number) => `${v}%`}
+                tick={{
+                  fontFamily: "var(--bt-font-mono)",
+                  fontSize: 10,
+                  fill: "var(--bt-text-muted)",
+                }}
+                label={{
+                  value: m.wfh_x_label(),
+                  position: "insideBottom",
+                  offset: -12,
+                  style: {
+                    textAnchor: "middle",
+                    fontFamily: "var(--bt-font-body)",
+                    fontSize: 10,
+                    fill: "var(--bt-text-muted)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.06em",
+                  },
+                }}
+              />
 
-          {/* ── Optimal marker ────────────────────────────────────────── */}
-          {optimalIdx !== currentIdx && data[optimalIdx] && (
-            <>
-              <line
-                x1={xOpt}
-                x2={xOpt}
-                y1={PAD.top}
-                y2={H - PAD.bottom}
-                className="bt-wfh-optimal"
+              <YAxis
+                domain={[yLow, yHigh]}
+                tickFormatter={fmtK}
+                tick={{
+                  fontFamily: "var(--bt-font-mono)",
+                  fontSize: 10,
+                  fill: "var(--bt-text-muted)",
+                }}
+                width={60}
               />
-              <polygon
-                points={`${xOpt},${yOf(optimalNet) - 8} ${xOpt + 6},${yOf(optimalNet)} ${xOpt},${yOf(optimalNet) + 8} ${xOpt - 6},${yOf(optimalNet)}`}
-                className="bt-wfh-optimal-diamond"
-              />
-            </>
-          )}
 
-          {/* ── Current position ──────────────────────────────────────── */}
-          <line x1={xCur} x2={xCur} y1={PAD.top} y2={H - PAD.bottom} className="bt-wfh-current" />
-          {data[currentIdx] && (
-            <>
-              <circle
-                cx={xCur}
-                cy={yOf(data[currentIdx]!.netIncome)}
-                r="10"
-                className="bt-wfh-pulse"
+              {/* Threshold lines with chip labels */}
+              <ReferenceLine
+                x={T_90 * 100}
+                stroke="rgba(96,165,250,0.7)"
+                strokeDasharray="5 3"
+                strokeWidth={1.5}
+                label={(props: { x?: number; viewBox?: { y: number } }) => (
+                  <ThresholdLabel
+                    x={props.x}
+                    viewBox={props.viewBox}
+                    label={m.wfh_threshold_10_label()}
+                    color="rgba(96,165,250,0.9)"
+                    bg="rgba(96,165,250,0.15)"
+                  />
+                )}
               />
-              <circle
-                cx={xCur}
-                cy={yOf(data[currentIdx]!.netIncome)}
-                r="5"
-                className="bt-wfh-current-dot"
+              <ReferenceLine
+                x={T_25 * 100}
+                stroke="rgba(245,158,11,0.7)"
+                strokeDasharray="5 3"
+                strokeWidth={1.5}
+                label={(props: { x?: number; viewBox?: { y: number } }) => (
+                  <ThresholdLabel
+                    x={props.x}
+                    viewBox={props.viewBox}
+                    label={m.wfh_threshold_25_label()}
+                    color="rgba(245,158,11,0.9)"
+                    bg="rgba(245,158,11,0.12)"
+                  />
+                )}
               />
-            </>
-          )}
+              <ReferenceLine
+                x={T_49 * 100}
+                stroke="rgba(168,85,247,0.7)"
+                strokeDasharray="5 3"
+                strokeWidth={1.5}
+                label={(props: { x?: number; viewBox?: { y: number } }) => (
+                  <ThresholdLabel
+                    x={props.x}
+                    viewBox={props.viewBox}
+                    label={m.wfh_threshold_49_label()}
+                    color="rgba(168,85,247,0.9)"
+                    bg="rgba(168,85,247,0.12)"
+                  />
+                )}
+              />
 
-          {/* ── Hover scrubber ────────────────────────────────────────── */}
-          {hovered !== null && hovered !== currentIdx && data[hovered] && (
-            <>
-              <line
-                x1={xIdx(hovered)}
-                x2={xIdx(hovered)}
-                y1={PAD.top}
-                y2={H - PAD.bottom}
-                className="bt-wfh-scrubber"
+              {/* Current position line */}
+              <ReferenceLine
+                x={data[currentIdx]?.x}
+                stroke="rgba(255,255,255,0.55)"
+                strokeDasharray="6 4"
+                strokeWidth={1.5}
+                className="bt-wfh-current"
               />
-              <circle
-                cx={xIdx(hovered)}
-                cy={yOf(data[hovered]!.netIncome)}
-                r={4}
-                className="bt-wfh-dot bt-wfh-dot--net"
-              />
-              <circle
-                cx={xIdx(hovered)}
-                cy={yOf(data[hovered]!.nlTax)}
-                r={3}
-                className="bt-wfh-dot bt-wfh-dot--nl"
-              />
-              {showBE && (
-                <circle
-                  cx={xIdx(hovered)}
-                  cy={yOf(data[hovered]!.beTax)}
-                  r={3}
-                  className="bt-wfh-dot bt-wfh-dot--be"
+
+              {/* Optimal position line */}
+              {optimalIdx !== currentIdx && (
+                <ReferenceLine
+                  x={data[optimalIdx]?.x}
+                  stroke="var(--bt-success)"
+                  strokeDasharray="3 3"
+                  strokeWidth={1}
+                  opacity={0.55}
                 />
               )}
-            </>
-          )}
-        </svg>
+
+              {/* Net income area */}
+              <Area
+                type="monotone"
+                dataKey="netIncome"
+                fill="url(#wfh-net-grad)"
+                stroke="var(--bt-success)"
+                strokeWidth={2.5}
+                dot={false}
+                activeDot={{
+                  r: 4,
+                  fill: "var(--bt-success)",
+                  stroke: "var(--bt-bg)",
+                  strokeWidth: 2,
+                }}
+                isAnimationActive={false}
+              />
+
+              {/* NL Tax line */}
+              <Line
+                type="monotone"
+                dataKey="nlTax"
+                stroke="var(--bt-nl)"
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 3, fill: "var(--bt-nl)", stroke: "var(--bt-bg)", strokeWidth: 2 }}
+                opacity={0.85}
+                isAnimationActive={false}
+              />
+
+              {/* BE Tax line */}
+              {showBE && (
+                <Line
+                  type="monotone"
+                  dataKey="beTax"
+                  stroke="var(--bt-be)"
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{
+                    r: 3,
+                    fill: "var(--bt-be)",
+                    stroke: "var(--bt-bg)",
+                    strokeWidth: 2,
+                  }}
+                  opacity={0.85}
+                  isAnimationActive={false}
+                />
+              )}
+
+              {/* Current position dot */}
+              {data[currentIdx] && (
+                <ReferenceDot
+                  x={data[currentIdx]!.x}
+                  y={data[currentIdx]!.netIncome}
+                  r={5}
+                  fill="var(--bt-bg)"
+                  stroke="rgba(255,255,255,0.85)"
+                  strokeWidth={2.5}
+                  className="bt-wfh-current-dot"
+                />
+              )}
+
+              {/* Optimal position diamond */}
+              {optimalIdx !== currentIdx && data[optimalIdx] && (
+                <ReferenceDot
+                  x={data[optimalIdx]!.x}
+                  y={data[optimalIdx]!.netIncome}
+                  r={0}
+                  shape={(props: { cx?: number; cy?: number }) => {
+                    const { cx, cy } = props;
+                    if (cx == null || cy == null) return <g />;
+                    return (
+                      <polygon
+                        points={`${cx},${cy - 8} ${cx + 6},${cy} ${cx},${cy + 8} ${cx - 6},${cy}`}
+                        fill="var(--bt-success)"
+                        opacity={0.9}
+                      />
+                    );
+                  }}
+                />
+              )}
+
+              {/* Scrubber cursor without tooltip box */}
+              <Tooltip
+                content={() => null}
+                cursor={{ stroke: "var(--bt-text-dim)", strokeWidth: 1, strokeOpacity: 0.5 }}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
 
         {/* ── Legend — directly below chart, above readout ──────────── */}
         <div className="bt-year-chart__legend bt-wfh-legend">
@@ -529,11 +455,11 @@ export default function WFHRatioChart({ inputs }: Props) {
         </div>
 
         {/* ── Readout bar ───────────────────────────────────────────── */}
-        <div className={`bt-wfh-readout${isHovering ? " bt-wfh-readout--visible" : ""}`}>
+        <div className={clsx("bt-wfh-readout", isHovering && "bt-wfh-readout--visible")}>
           {displayPoint ? (
             <>
               <span
-                className={`bt-wfh-readout__label${isHovering ? "" : " bt-wfh-readout__label--current"}`}
+                className={clsx("bt-wfh-readout__label", !isHovering && "bt-wfh-readout__label--current")}
               >
                 {!isHovering && (
                   <span className="bt-wfh-readout__tag">{m.wfh_current_ratio()}</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -58,7 +58,7 @@
   --bt-warning-border: rgba(245, 158, 11, 0.3);
 
   /* Typography */
-  --bt-font-body: "Inter Variable", "Inter", system-ui, -apple-system, sans-serif;
+  --bt-font-body: "Inter Variable", system-ui, -apple-system, sans-serif;
   --bt-font-mono: "Space Mono", "Courier New", monospace;
 
   /* Radii */
@@ -1345,199 +1345,17 @@ footer a:hover {
   position: relative;
 }
 
-.bt-wfh-svg {
-  width: 100%;
-  height: auto;
-  display: block;
-  cursor: crosshair;
+.bt-wfh-recharts {
   border-radius: var(--bt-r);
   background: var(--bt-surface-2);
   border: 1px solid var(--bt-border);
-  overflow: visible; /* let glow spill outside */
+  cursor: crosshair;
+  touch-action: pan-y;
 }
 
-/* ── Background zones ─────────────────────────────────────────── */
-.bt-wfh-zone {
-  pointer-events: none;
-}
-.bt-wfh-zone--full {
-  fill: rgba(34, 197, 94, 0.06);
-}
-.bt-wfh-zone--hybrid {
-  fill: rgba(96, 165, 250, 0.025);
-}
-.bt-wfh-zone--kaderakkoord {
-  fill: rgba(168, 85, 247, 0.025);
-}
-.bt-wfh-zone--above {
-  fill: rgba(245, 158, 11, 0.025);
-}
-
-/* Coloured top-edge accent per zone */
-.bt-wfh-zone-edge {
-  stroke-width: 2;
-  pointer-events: none;
-}
-.bt-wfh-zone-edge--full {
-  stroke: rgba(34, 197, 94, 0.5);
-}
-.bt-wfh-zone-edge--hybrid {
-  stroke: rgba(96, 165, 250, 0.35);
-}
-.bt-wfh-zone-edge--kaderakkoord {
-  stroke: rgba(168, 85, 247, 0.35);
-}
-.bt-wfh-zone-edge--above {
-  stroke: rgba(245, 158, 11, 0.35);
-}
-
-/* ── Grid & axes ──────────────────────────────────────────────── */
-.bt-wfh-grid {
-  stroke: var(--bt-border-soft);
-  stroke-width: 1;
-}
-
-.bt-wfh-axis-label {
-  font-family: var(--bt-font-mono);
-  font-size: 10px;
-  fill: var(--bt-text-muted);
-}
-
-.bt-wfh-axis-title {
-  font-family: var(--bt-font-body);
-  font-size: 10px;
-  fill: var(--bt-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-/* ── Threshold lines ──────────────────────────────────────────── */
-.bt-wfh-threshold {
-  stroke-width: 1.5;
-  stroke-dasharray: 5 3;
-  pointer-events: none;
-}
-.bt-wfh-threshold--10 {
-  stroke: rgba(96, 165, 250, 0.7);
-}
-.bt-wfh-threshold--25 {
-  stroke: rgba(245, 158, 11, 0.7);
-}
-.bt-wfh-threshold--49 {
-  stroke: rgba(168, 85, 247, 0.7);
-}
-
-/* Floating chip labels inside SVG */
-.bt-wfh-chip-bg--10 {
-  fill: rgba(96, 165, 250, 0.15);
-}
-.bt-wfh-chip-bg--25 {
-  fill: rgba(245, 158, 11, 0.12);
-}
-.bt-wfh-chip-bg--49 {
-  fill: rgba(168, 85, 247, 0.12);
-}
-
-.bt-wfh-chip-text {
-  font-family: var(--bt-font-mono);
-  font-size: 8px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-.bt-wfh-chip-text--10 {
-  fill: rgba(96, 165, 250, 0.9);
-}
-.bt-wfh-chip-text--25 {
-  fill: rgba(245, 158, 11, 0.9);
-}
-.bt-wfh-chip-text--49 {
-  fill: rgba(168, 85, 247, 0.9);
-}
-
-/* ── Data lines ───────────────────────────────────────────────── */
-.bt-wfh-line {
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-.bt-wfh-line--net {
-  stroke: var(--bt-success);
-  stroke-width: 2.5;
-}
-.bt-wfh-line--nl {
-  stroke: var(--bt-nl);
-  stroke-width: 2;
-  opacity: 0.85;
-}
-.bt-wfh-line--be {
-  stroke: var(--bt-be);
-  stroke-width: 2;
-  opacity: 0.85;
-}
-
-/* ── Hover dots ───────────────────────────────────────────────── */
-.bt-wfh-dot {
-  stroke: var(--bt-bg);
-  stroke-width: 2;
-}
-.bt-wfh-dot--net {
-  fill: var(--bt-success);
-}
-.bt-wfh-dot--nl {
-  fill: var(--bt-nl);
-}
-.bt-wfh-dot--be {
-  fill: var(--bt-be);
-}
-
-/* ── Current position marker ──────────────────────────────────── */
-.bt-wfh-current {
-  stroke: rgba(255, 255, 255, 0.55);
-  stroke-width: 1.5;
-  stroke-dasharray: 6 4;
-}
-
-.bt-wfh-current-dot {
-  fill: var(--bt-bg);
-  stroke: rgba(255, 255, 255, 0.85);
-  stroke-width: 2.5;
-}
-
-/* Pulsing outer ring on the current-position dot */
-.bt-wfh-pulse {
-  fill: none;
-  stroke: rgba(255, 255, 255, 0.25);
-  stroke-width: 1.5;
-  animation: wfh-pulse 2.4s ease-out infinite;
-}
-
-@keyframes wfh-pulse {
-  0% {
-    r: 7;
-    opacity: 0.5;
-  }
-  100% {
-    r: 16;
-    opacity: 0;
-  }
-}
-
-/* ── Optimal marker ───────────────────────────────────────────── */
-.bt-wfh-optimal {
-  stroke: var(--bt-success);
-  stroke-width: 1;
-  stroke-dasharray: 3 3;
-  opacity: 0.55;
-}
-.bt-wfh-optimal-diamond {
-  fill: var(--bt-success);
-  opacity: 0.9;
-}
-
-/* ── Hover scrubber ───────────────────────────────────────────── */
-.bt-wfh-scrubber {
-  stroke: rgba(255, 255, 255, 0.3);
-  stroke-width: 1;
+/* Suppress the default recharts tooltip wrapper box */
+.bt-wfh-recharts .recharts-tooltip-wrapper {
+  display: none;
 }
 
 /* ── Hover readout bar ────────────────────────────────────────── */
@@ -1990,17 +1808,6 @@ footer a:hover {
   stroke: rgba(0, 0, 0, 0.7);
 }
 
-[data-bs-theme="light"] .bt-wfh-pulse {
-  stroke: rgba(0, 0, 0, 0.15);
-}
-
-[data-bs-theme="light"] .bt-wfh-scrubber {
-  stroke: rgba(0, 0, 0, 0.2);
-}
-
-[data-bs-theme="light"] .bt-wfh-dot {
-  stroke: var(--bt-bg);
-}
 
 [data-bs-theme="light"] .bt-year-chart__row:hover {
   background: rgba(0, 0, 0, 0.04);

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,12 +6,19 @@
 /* ── Design Tokens ────────────────────────────────────────────── */
 
 :root {
-  /* Surfaces */
+  /* Brand — teal identity for a finance/tax tool */
+  --bt-brand: #0d9488;
+  --bt-brand-light: #14b8a6;
+  --bt-brand-dim: rgba(13, 148, 136, 0.12);
+  --bt-brand-border: rgba(13, 148, 136, 0.35);
+
+  /* Surfaces — dark mode defaults */
   --bt-bg: #07090f;
   --bt-surface: #0d1220;
   --bt-surface-2: #121829;
   --bt-surface-3: #1a2235;
   --bt-surface-4: #222c42;
+  --bt-navbar-bg: rgba(7, 9, 15, 0.92);
 
   /* Borders */
   --bt-border: rgba(255, 255, 255, 0.065);
@@ -20,18 +27,18 @@
 
   /* Text */
   --bt-text: #d4e4f5;
-  --bt-text-sub: #8ba8c5; /* 7.0:1 on surface-2 — secondary labels */
-  --bt-text-muted: #7090b0; /* 5.2:1 on surface-2 — passes AA normal text */
-  --bt-text-dim: #4e6884; /* 3.2:1 on surface-2 — large/decorative only */
+  --bt-text-sub: #8ba8c5;
+  --bt-text-muted: #7090b0;
+  --bt-text-dim: #4e6884;
 
-  /* Dutch Orange — the kingdom across the northern border */
+  /* Dutch Orange — demoted to per-tab accent only */
   --bt-nl: #e05020;
   --bt-nl-light: #f07040;
   --bt-nl-dim: rgba(224, 80, 32, 0.12);
   --bt-nl-glow: rgba(224, 80, 32, 0.25);
   --bt-nl-border: rgba(224, 80, 32, 0.35);
 
-  /* Belgian Gold — land of beer, chocolate, and complex taxes */
+  /* Belgian Gold — demoted to per-tab accent only */
   --bt-be: #c8901a;
   --bt-be-light: #e0a830;
   --bt-be-dim: rgba(200, 144, 26, 0.12);
@@ -67,8 +74,8 @@
   --bs-font-sans-serif: var(--bt-font-body);
   --bs-font-monospace: var(--bt-font-mono);
 
-  --bs-primary: #4a8fd4;
-  --bs-primary-rgb: 74, 143, 212;
+  --bs-primary: var(--bt-brand);
+  --bs-primary-rgb: 13, 148, 136;
   --bs-success-rgb: 34, 197, 94;
   --bs-danger-rgb: 239, 68, 68;
   --bs-warning-rgb: 245, 158, 11;
@@ -76,8 +83,47 @@
   --bs-secondary-rgb: 78, 104, 132;
   --bs-dark-rgb: 13, 18, 32;
 
-  --bs-link-color: var(--bt-info);
+  --bs-link-color: var(--bt-brand-light);
   --bs-link-hover-color: var(--bt-text);
+}
+
+/* ── Light mode token overrides ───────────────────────────────── */
+
+[data-bs-theme="light"] {
+  --bt-bg: #f8f9fa;
+  --bt-surface: #ffffff;
+  --bt-surface-2: #f0f4f8;
+  --bt-surface-3: #e4eaf1;
+  --bt-surface-4: #d8e2ec;
+  --bt-navbar-bg: rgba(248, 249, 250, 0.95);
+
+  --bt-border: rgba(0, 0, 0, 0.1);
+  --bt-border-soft: rgba(0, 0, 0, 0.06);
+  --bt-border-hover: rgba(0, 0, 0, 0.18);
+
+  --bt-text: #0f1923;
+  --bt-text-sub: #2e4560;
+  --bt-text-muted: #4a6480;
+  --bt-text-dim: #7a9ab8;
+
+  --bt-success: #16a34a;
+  --bt-success-dim: rgba(22, 163, 74, 0.1);
+  --bt-danger: #dc2626;
+  --bt-danger-dim: rgba(220, 38, 38, 0.08);
+  --bt-warning: #d97706;
+  --bt-warning-dim: rgba(217, 119, 6, 0.08);
+  --bt-warning-border: rgba(217, 119, 6, 0.3);
+  --bt-info: #2563eb;
+  --bt-info-dim: rgba(37, 99, 235, 0.08);
+  --bt-info-border: rgba(37, 99, 235, 0.25);
+
+  --bs-body-bg: var(--bt-bg);
+  --bs-body-color: var(--bt-text);
+  --bs-border-color: var(--bt-border);
+  --bs-secondary-color: var(--bt-text-sub);
+  --bs-link-color: var(--bt-brand);
+  --bs-link-hover-color: var(--bt-text);
+  --bs-secondary-rgb: 74, 100, 128;
 }
 
 /* ── Base ─────────────────────────────────────────────────────── */
@@ -93,12 +139,15 @@ html {
   color-scheme: dark;
 }
 
+[data-bs-theme="light"] {
+  color-scheme: light;
+}
+
 body {
   background-color: var(--bt-bg);
   background-image:
-    radial-gradient(ellipse 70% 45% at 15% 0%, rgba(224, 80, 32, 0.055) 0%, transparent 60%),
-    radial-gradient(ellipse 55% 40% at 85% 100%, rgba(200, 144, 26, 0.055) 0%, transparent 60%),
-    radial-gradient(ellipse 40% 50% at 50% 50%, rgba(7, 9, 15, 0) 0%, transparent 100%);
+    radial-gradient(ellipse 70% 45% at 15% 0%, rgba(13, 148, 136, 0.06) 0%, transparent 60%),
+    radial-gradient(ellipse 55% 40% at 85% 100%, rgba(13, 148, 136, 0.04) 0%, transparent 60%);
   min-height: 100vh;
   color: var(--bt-text);
   font-family: var(--bt-font-body);
@@ -140,7 +189,7 @@ h6 {
 /* ── Navbar ───────────────────────────────────────────────────── */
 
 .navbar {
-  background: rgba(7, 9, 15, 0.92) !important;
+  background: var(--bt-navbar-bg) !important;
   backdrop-filter: blur(24px) saturate(160%);
   -webkit-backdrop-filter: blur(24px) saturate(160%);
   border-bottom: 1px solid var(--bt-border);
@@ -204,7 +253,7 @@ h6 {
   --bs-accordion-btn-bg: var(--bt-surface);
   --bs-accordion-active-color: var(--bt-text);
   --bs-accordion-active-bg: var(--bt-surface-2);
-  --bs-accordion-btn-focus-box-shadow: 0 0 0 3px var(--bt-nl-dim);
+  --bs-accordion-btn-focus-box-shadow: 0 0 0 3px var(--bt-brand-dim);
   border-radius: var(--bt-r-lg);
   overflow: hidden;
   border: 1px solid var(--bt-border);
@@ -243,9 +292,9 @@ h6 {
 /* Single definition; applied consistently to every focusable element */
 
 :focus-visible {
-  outline: 2px solid var(--bt-nl-border) !important;
+  outline: 2px solid var(--bt-brand-border) !important;
   outline-offset: 2px !important;
-  box-shadow: 0 0 0 4px var(--bt-nl-dim) !important;
+  box-shadow: 0 0 0 4px var(--bt-brand-dim) !important;
 }
 
 /* Suppress the default :focus ring (only show on keyboard nav) */
@@ -260,9 +309,9 @@ h6 {
 }
 
 .accordion-button:focus-visible {
-  outline: 2px solid var(--bt-nl-border) !important;
+  outline: 2px solid var(--bt-brand-border) !important;
   outline-offset: -2px !important;
-  box-shadow: 0 0 0 4px var(--bt-nl-dim) !important;
+  box-shadow: 0 0 0 4px var(--bt-brand-dim) !important;
 }
 
 .accordion-button::after {
@@ -322,8 +371,8 @@ h6 {
 .form-control:focus,
 .form-select:focus {
   background: var(--bt-surface-3) !important;
-  border-color: var(--bt-nl-border) !important;
-  box-shadow: 0 0 0 3px var(--bt-nl-dim) !important;
+  border-color: var(--bt-brand-border) !important;
+  box-shadow: 0 0 0 3px var(--bt-brand-dim) !important;
   color: var(--bt-text) !important;
   /* outline handled by :focus-visible above */
   outline: none !important;
@@ -369,13 +418,13 @@ h6 {
 }
 
 .form-check-input:checked {
-  background-color: var(--bt-nl) !important;
-  border-color: var(--bt-nl) !important;
+  background-color: var(--bt-brand) !important;
+  border-color: var(--bt-brand) !important;
 }
 
 .form-check-input:focus-visible {
-  box-shadow: 0 0 0 3px var(--bt-nl-dim) !important;
-  border-color: var(--bt-nl-border) !important;
+  box-shadow: 0 0 0 3px var(--bt-brand-dim) !important;
+  border-color: var(--bt-brand-border) !important;
 }
 
 /* ── Badges ───────────────────────────────────────────────────── */
@@ -395,9 +444,9 @@ h6 {
 
 .badge.bg-primary,
 .bg-primary {
-  background: rgba(74, 143, 212, 0.25) !important;
-  color: var(--bt-info) !important;
-  border: 1px solid rgba(74, 143, 212, 0.35) !important;
+  background: var(--bt-brand-dim) !important;
+  color: var(--bt-brand-light) !important;
+  border: 1px solid var(--bt-brand-border) !important;
 }
 
 /* ── Tables ───────────────────────────────────────────────────── */
@@ -458,11 +507,11 @@ h6 {
 }
 
 .table-primary {
-  --bs-table-bg: rgba(74, 143, 212, 0.09) !important;
+  --bs-table-bg: rgba(13, 148, 136, 0.09) !important;
 }
 .table-primary td,
 .table-primary th {
-  background: rgba(74, 143, 212, 0.09) !important;
+  background: rgba(13, 148, 136, 0.09) !important;
   color: var(--bt-text) !important;
 }
 
@@ -531,14 +580,14 @@ h6 {
 }
 
 .btn-outline-primary {
-  color: var(--bt-info) !important;
-  border-color: rgba(96, 165, 250, 0.35) !important;
+  color: var(--bt-brand-light) !important;
+  border-color: var(--bt-brand-border) !important;
   background: transparent !important;
 }
 .btn-outline-primary:hover {
-  background: var(--bt-info-dim) !important;
-  border-color: rgba(96, 165, 250, 0.6) !important;
-  color: var(--bt-info) !important;
+  background: var(--bt-brand-dim) !important;
+  border-color: var(--bt-brand) !important;
+  color: var(--bt-brand-light) !important;
 }
 
 .btn-outline-secondary {
@@ -856,7 +905,7 @@ footer a:hover {
 /* ── Year comparison active row ──────────────────────────────── */
 
 .table-primary > td:first-child {
-  border-left: 2px solid var(--bt-info) !important;
+  border-left: 2px solid var(--bt-brand) !important;
 }
 
 /* ── Utility: number formatting ──────────────────────────────── */
@@ -1915,6 +1964,49 @@ footer a:hover {
 .bt-be-accent .bt-table-result .table-primary td:last-child {
   font-size: 1rem !important;
   color: var(--bt-be-light) !important;
+}
+
+/* ── Light mode component overrides ──────────────────────────── */
+
+[data-bs-theme="light"] .accordion {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+[data-bs-theme="light"] .tab-content {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+}
+
+[data-bs-theme="light"] .bt-stat-card:hover {
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+}
+
+[data-bs-theme="light"] .bt-wfh-current {
+  stroke: rgba(0, 0, 0, 0.4);
+}
+
+[data-bs-theme="light"] .bt-wfh-current-dot {
+  fill: var(--bt-bg);
+  stroke: rgba(0, 0, 0, 0.7);
+}
+
+[data-bs-theme="light"] .bt-wfh-pulse {
+  stroke: rgba(0, 0, 0, 0.15);
+}
+
+[data-bs-theme="light"] .bt-wfh-scrubber {
+  stroke: rgba(0, 0, 0, 0.2);
+}
+
+[data-bs-theme="light"] .bt-wfh-dot {
+  stroke: var(--bt-bg);
+}
+
+[data-bs-theme="light"] .bt-year-chart__row:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+[data-bs-theme="light"] .bt-wfh-legend-dash--current {
+  border-top-color: rgba(0, 0, 0, 0.35);
 }
 
 /* ═══════════════════════════════════════════════════════════════

--- a/src/styles.css
+++ b/src/styles.css
@@ -90,6 +90,7 @@
 /* ── Light mode token overrides ───────────────────────────────── */
 
 [data-bs-theme="light"] {
+  --bt-brand-light: #0f766e;
   --bt-bg: #f8f9fa;
   --bt-surface: #ffffff;
   --bt-surface-2: #f0f4f8;

--- a/src/tax/schema.ts
+++ b/src/tax/schema.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import {
+  VALID_BELGIAN_REGIONS,
+  VALID_CIVIL_STATUSES,
+  VALID_RESIDENT_COUNTRIES,
+} from "./constants";
+
+export const TaxInputSchema = z.object({
+  year: z
+    .union([
+      z.literal(2020),
+      z.literal(2021),
+      z.literal(2022),
+      z.literal(2023),
+      z.literal(2024),
+      z.literal(2025),
+    ])
+    .catch(2025),
+  residentCountry: z.enum(VALID_RESIDENT_COUNTRIES).catch("BE"),
+  civilStatus: z.enum(VALID_CIVIL_STATUSES).catch("single"),
+  dependentChildren: z
+    .number()
+    .catch(0)
+    .transform((v) => Math.min(10, Math.max(0, v))),
+  belowAOWAge: z.boolean().catch(true),
+  belgianRegion: z.enum(VALID_BELGIAN_REGIONS).catch("flemish"),
+  communalTaxRate: z
+    .number()
+    .catch(7)
+    .transform((v) => Math.min(15, Math.max(0, v))),
+  grossSalary: z.number().catch(60000).transform((v) => Math.max(0, v)),
+  daysWorkedNL: z.number().catch(200).transform((v) => Math.max(0, v)),
+  daysWorkedBE: z.number().catch(20).transform((v) => Math.max(0, v)),
+  daysWorkedOther: z.number().catch(0).transform((v) => Math.max(0, v)),
+  thirtyPercentRuling: z.boolean().catch(false),
+  socialContributions: z.number().catch(0).transform((v) => Math.max(0, v)),
+  aanvullendPensioen: z.number().catch(0).transform((v) => Math.max(0, v)),
+  dienstencheques: z.number().catch(0).transform((v) => Math.max(0, v)),
+  roerendeVoorheffing: z.number().catch(0).transform((v) => Math.max(0, v)),
+  withheldTaxNL: z.number().catch(0).transform((v) => Math.max(0, v)),
+  sickDays: z.number().catch(0).transform((v) => Math.max(0, v)),
+});
+
+export const PersistedInputsSchema = TaxInputSchema.pick({
+  year: true,
+  residentCountry: true,
+  civilStatus: true,
+  dependentChildren: true,
+  belowAOWAge: true,
+  belgianRegion: true,
+  communalTaxRate: true,
+  thirtyPercentRuling: true,
+});
+
+export type TaxInputs = z.infer<typeof TaxInputSchema>;
+export type PersistedInputs = z.infer<typeof PersistedInputsSchema>;

--- a/src/tax/types.ts
+++ b/src/tax/types.ts
@@ -1,37 +1,5 @@
-import type { TaxYear, ResidentCountry, CivilStatus, BelgianRegion } from "./constants";
-
-export interface TaxInputs {
-  year: TaxYear;
-  residentCountry: ResidentCountry;
-  civilStatus: CivilStatus;
-  dependentChildren: number;
-  belowAOWAge: boolean;
-  belgianRegion: BelgianRegion;
-  /** Municipal tax rate as a percentage, e.g. 7 for 7%. Typical Belgian range: 0–9%. */
-  communalTaxRate: number;
-  grossSalary: number;
-  daysWorkedNL: number;
-  daysWorkedBE: number;
-  /** Days worked in a third country (e.g. customer installation in France).
-   *  Belgium treats these identically to Belgian days (vol tarief) since the NL-BE treaty
-   *  only covers NL-sourced income. Default 0. */
-  daysWorkedOther?: number;
-  thirtyPercentRuling: boolean;
-  /** Belgian social contributions (eigen bijdragen) — deductible from Belgian declared income. Default 0. */
-  socialContributions?: number;
-  /** Supplementary pension contributions (code 1285) — 30% reduction applies. Default 0. */
-  aanvullendPensioen?: number;
-  /** Diensten-cheques amount (code 3364) — 20% reduction applies. Default 0. */
-  dienstencheques?: number;
-  /** Roerende voorheffing / withholding tax already paid (code 1437). Default 0. */
-  roerendeVoorheffing?: number;
-  /** NL wage tax withheld by employer (ingehouden loonheffing from jaaropgave).
-   *  Used to compute NL refund/payment and net eindafrekening. Default 0. */
-  withheldTaxNL?: number;
-  /** Sick days during the year. NL and BE use different methods to account for sick days
-   *  when calculating the income sourcing fraction. Default 0. */
-  sickDays?: number;
-}
+import type { TaxInputs } from "./schema";
+export type { TaxInputs };
 
 export interface BracketLine {
   label: string;

--- a/tests/components/InputPanel.test.tsx
+++ b/tests/components/InputPanel.test.tsx
@@ -1,10 +1,24 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useForm } from "@tanstack/react-form";
 
-import InputPanel from "@/components/InputPanel";
+import InputPanel, { type TaxFormApi } from "@/components/InputPanel";
 import type { TaxInputs } from "@/tax/types";
 import { setLocale } from "@/paraglide/runtime";
 import { mockInputs } from "../test-utils/mockData";
+
+function renderInputPanel(overrides: Partial<TaxInputs> = {}) {
+  let formInstance!: TaxFormApi;
+
+  function Wrapper() {
+    const form = useForm({ defaultValues: { ...mockInputs, ...overrides } });
+    formInstance = form as TaxFormApi;
+    return <InputPanel form={formInstance} />;
+  }
+
+  render(<Wrapper />);
+  return { getForm: () => formInstance };
+}
 
 describe("InputPanel", () => {
   beforeEach(() => {
@@ -12,13 +26,11 @@ describe("InputPanel", () => {
   });
 
   it("renders without crashing", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+    renderInputPanel();
   });
 
   it("shows communal tax field for BE residents", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={{ ...mockInputs, residentCountry: "BE" }} onChange={onChange} />);
+    renderInputPanel({ residentCountry: "BE" });
     // Year is the only combobox shown (resident country, civil status and Belgian region
     // dropdowns are hidden when there is only one valid option each)
     const selects = screen.getAllByRole("combobox");
@@ -27,168 +39,131 @@ describe("InputPanel", () => {
     expect(screen.getAllByRole("spinbutton").length).toBeGreaterThanOrEqual(5);
   });
 
-  it("calls onChange when year dropdown is changed", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates year when dropdown is changed", () => {
+    const { getForm } = renderInputPanel();
     const selects = screen.getAllByRole("combobox");
     fireEvent.change(selects[0]!, { target: { value: "2024" } });
-    expect(onChange).toHaveBeenCalledOnce();
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ year: 2024 }));
+    expect(getForm().getFieldValue("year")).toBe(2024);
   });
 
   // TODO: Re-enable when NL-resident support is re-integrated
   it.skip("hides Belgian region and communal tax fields for NL residents", () => {
-    const onChange = vi.fn();
-    const nlInputs = { ...mockInputs, residentCountry: "NL" as unknown as TaxInputs["residentCountry"] };
-    render(<InputPanel inputs={nlInputs} onChange={onChange} />);
+    renderInputPanel({
+      residentCountry: "NL" as unknown as TaxInputs["residentCountry"],
+    });
     const selects = screen.getAllByRole("combobox");
     expect(selects.length).toBe(3);
     expect(screen.queryByText(/municipal tax|communal tax|gemeentebelasting/i)).toBeNull();
-    // Sick days field should be present for NL residents
     expect(screen.getByRole("spinbutton", { name: /sick days/i })).toBeInTheDocument();
-    // Municipal/communal tax spinbutton should not be rendered for NL residents
     expect(screen.queryByRole("spinbutton", { name: /municipal tax|communal tax/i })).toBeNull();
   });
 
   // TODO: Re-enable when NL-resident support is re-integrated
-  it.skip("calls onChange when resident country changes to NL", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it.skip("updates resident country to NL", () => {
+    const { getForm } = renderInputPanel();
     const selects = screen.getAllByRole("combobox");
     fireEvent.change(selects[1]!, { target: { value: "NL" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ residentCountry: "NL" }));
+    expect(getForm().getFieldValue("residentCountry")).toBe("NL");
   });
 
   // TODO: Re-enable when multiple civil statuses are supported
-  it.skip("calls onChange when civil status changes", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it.skip("updates civil status", () => {
+    const { getForm } = renderInputPanel();
     const selects = screen.getAllByRole("combobox");
     fireEvent.change(selects[2]!, { target: { value: "married" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ civilStatus: "married" }));
+    expect(getForm().getFieldValue("civilStatus")).toBe("married");
   });
 
   // TODO: Re-enable when multiple Belgian regions are supported
-  it.skip("calls onChange when belgian region changes", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={{ ...mockInputs, residentCountry: "BE" }} onChange={onChange} />);
+  it.skip("updates belgian region", () => {
+    const { getForm } = renderInputPanel({ residentCountry: "BE" });
     const selects = screen.getAllByRole("combobox");
-    // belgianRegion is the 4th dropdown (index 3)
     fireEvent.change(selects[3]!, { target: { value: "walloon" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ belgianRegion: "walloon" }));
+    expect(getForm().getFieldValue("belgianRegion")).toBe("walloon");
   });
 
-  it("calls onChange when communal tax rate changes", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={{ ...mockInputs, residentCountry: "BE" }} onChange={onChange} />);
+  it("updates communal tax rate", () => {
+    const { getForm } = renderInputPanel({ residentCountry: "BE" });
     // For BE resident: spinbuttons are [dependentChildren, communalTaxRate, grossSalary, daysWorkedNL, daysWorkedBE]
     const inputs = screen.getAllByRole("spinbutton");
     fireEvent.change(inputs[1]!, { target: { value: "8" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ communalTaxRate: 8 }));
+    expect(getForm().getFieldValue("communalTaxRate")).toBe(8);
   });
 
-  it("calls onChange when gross salary is updated", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates gross salary", () => {
+    const { getForm } = renderInputPanel();
     // For BE resident: spinbuttons are [dependentChildren, communalTaxRate, grossSalary, daysWorkedNL, daysWorkedBE]
     const inputs = screen.getAllByRole("spinbutton");
     const grossSalaryInput = inputs[2]!;
     fireEvent.change(grossSalaryInput, { target: { value: "80000" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ grossSalary: 80000 }));
+    expect(getForm().getFieldValue("grossSalary")).toBe(80000);
   });
 
-  it("calls onChange when daysWorkedNL is updated", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates daysWorkedNL", () => {
+    const { getForm } = renderInputPanel();
     const inputs = screen.getAllByRole("spinbutton");
     fireEvent.change(inputs[4]!, { target: { value: "150" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ daysWorkedNL: 150 }));
+    expect(getForm().getFieldValue("daysWorkedNL")).toBe(150);
   });
 
-  it("calls onChange when daysWorkedBE is updated", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates daysWorkedBE", () => {
+    const { getForm } = renderInputPanel();
     const inputs = screen.getAllByRole("spinbutton");
     fireEvent.change(inputs[5]!, { target: { value: "30" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ daysWorkedBE: 30 }));
+    expect(getForm().getFieldValue("daysWorkedBE")).toBe(30);
   });
 
-  it("calls onChange when AOW checkbox is toggled", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates belowAOWAge when checkbox is toggled", () => {
+    const { getForm } = renderInputPanel();
     const checkbox = screen.getByRole("checkbox", { name: /aow/i });
     fireEvent.click(checkbox);
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ belowAOWAge: false }));
+    expect(getForm().getFieldValue("belowAOWAge")).toBe(false);
   });
 
-  it("calls onChange when thirty percent ruling is toggled", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates thirtyPercentRuling when checkbox is toggled", () => {
+    const { getForm } = renderInputPanel();
     const checkboxes = screen.getAllByRole("checkbox");
     // thirtyPercentRuling checkbox is the second checkbox
     fireEvent.click(checkboxes[1]!);
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ thirtyPercentRuling: true }));
+    expect(getForm().getFieldValue("thirtyPercentRuling")).toBe(true);
   });
 
-  it("calls onChange when dependents count is updated", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates dependents count", () => {
+    const { getForm } = renderInputPanel();
     const inputs = screen.getAllByRole("spinbutton");
     fireEvent.change(inputs[0]!, { target: { value: "2" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ dependentChildren: 2 }));
+    expect(getForm().getFieldValue("dependentChildren")).toBe(2);
   });
 
-  it("clamps dependent children to the allowed maximum", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
-    const inputs = screen.getAllByRole("spinbutton");
-    fireEvent.change(inputs[0]!, { target: { value: "99" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ dependentChildren: 10 }));
+  it("allows out-of-range dependents and surfaces a validation error", () => {
+    const { getForm } = renderInputPanel();
+    const spinButtons = screen.getAllByRole("spinbutton");
+    fireEvent.change(spinButtons[0]!, { target: { value: "99" } });
+    // Raw form value is unclamped — clamping happens at the App layer via TaxInputSchema.parse
+    expect(getForm().getFieldValue("dependentChildren")).toBe(99);
+    // Zod validator marks the input as invalid
+    expect(spinButtons[0]).toHaveClass("is-invalid");
   });
 
   it("shows total workdays count", () => {
-    const onChange = vi.fn();
-    render(
-      <InputPanel
-        inputs={{ ...mockInputs, daysWorkedNL: 180, daysWorkedBE: 20, daysWorkedOther: 5 }}
-        onChange={onChange}
-      />,
-    );
+    renderInputPanel({ daysWorkedNL: 180, daysWorkedBE: 20, daysWorkedOther: 5 });
     // 180 + 20 + 5 = 205 — shown inline as "Total workdays: 205"
     expect(screen.getByText(/205/)).toBeInTheDocument();
   });
 
   it("shows a warning when total workdays is zero", () => {
-    const onChange = vi.fn();
-    render(
-      <InputPanel
-        inputs={{ ...mockInputs, daysWorkedNL: 0, daysWorkedBE: 0, daysWorkedOther: 0 }}
-        onChange={onChange}
-      />,
-    );
+    renderInputPanel({ daysWorkedNL: 0, daysWorkedBE: 0, daysWorkedOther: 0 });
     expect(screen.getByText(/realistic net\/day|realistische netto\/dag/i)).toBeInTheDocument();
   });
 
   it("shows a warning when workdays total exceeds a typical yearly range", () => {
-    const onChange = vi.fn();
-    render(
-      <InputPanel
-        inputs={{ ...mockInputs, daysWorkedNL: 260, daysWorkedBE: 120, daysWorkedOther: 20 }}
-        onChange={onChange}
-      />,
-    );
+    renderInputPanel({ daysWorkedNL: 260, daysWorkedBE: 120, daysWorkedOther: 20 });
     expect(screen.getByText(/total workdays|totaal aantal werkdagen/i)).toBeInTheDocument();
     expect(screen.getByText(/double-check|controleer/i)).toBeInTheDocument();
   });
 
   it("does not show high workdays warning when total is within normal range", () => {
-    const onChange = vi.fn();
-    render(
-      <InputPanel
-        inputs={{ ...mockInputs, daysWorkedNL: 200, daysWorkedBE: 20, daysWorkedOther: 0 }}
-        onChange={onChange}
-      />,
-    );
+    renderInputPanel({ daysWorkedNL: 200, daysWorkedBE: 20, daysWorkedOther: 0 });
     expect(screen.queryByText(/double-check|controleer/i)).toBeNull();
   });
 });

--- a/tests/tax/be.test.ts
+++ b/tests/tax/be.test.ts
@@ -15,11 +15,14 @@ const base: TaxInputs = {
   grossSalary: 60000,
   daysWorkedNL: 220,
   daysWorkedBE: 0,
+  daysWorkedOther: 0,
   thirtyPercentRuling: false,
   socialContributions: 0,
   aanvullendPensioen: 0,
   dienstencheques: 0,
   roerendeVoorheffing: 0,
+  withheldTaxNL: 0,
+  sickDays: 0,
 };
 
 function mockNL(overrides?: Partial<NLTaxResult>): NLTaxResult {

--- a/tests/tax/index.test.ts
+++ b/tests/tax/index.test.ts
@@ -14,7 +14,14 @@ const base: TaxInputs = {
   grossSalary: 60000,
   daysWorkedNL: 220,
   daysWorkedBE: 0,
+  daysWorkedOther: 0,
   thirtyPercentRuling: false,
+  socialContributions: 0,
+  aanvullendPensioen: 0,
+  dienstencheques: 0,
+  roerendeVoorheffing: 0,
+  withheldTaxNL: 0,
+  sickDays: 0,
 };
 
 describe("calculate", () => {

--- a/tests/tax/nl.test.ts
+++ b/tests/tax/nl.test.ts
@@ -14,7 +14,14 @@ const base: TaxInputs = {
   grossSalary: 60000,
   daysWorkedNL: 220,
   daysWorkedBE: 0,
+  daysWorkedOther: 0,
   thirtyPercentRuling: false,
+  socialContributions: 0,
+  aanvullendPensioen: 0,
+  dienstencheques: 0,
+  roerendeVoorheffing: 0,
+  withheldTaxNL: 0,
+  sickDays: 0,
 };
 
 describe("calculateNLTax", () => {

--- a/tests/tax/workdays.test.ts
+++ b/tests/tax/workdays.test.ts
@@ -30,6 +30,12 @@ describe("getTotalWorkdays", () => {
         daysWorkedBE: 10,
         daysWorkedOther: 5,
         thirtyPercentRuling: false,
+        socialContributions: 0,
+        aanvullendPensioen: 0,
+        dienstencheques: 0,
+        roerendeVoorheffing: 0,
+        withheldTaxNL: 0,
+        sickDays: 0,
       }),
     ).toBe(235);
   });

--- a/tests/test-utils/mockData.ts
+++ b/tests/test-utils/mockData.ts
@@ -11,11 +11,14 @@ export const mockInputs: TaxInputs = {
   grossSalary: 60000,
   daysWorkedNL: 200,
   daysWorkedBE: 20,
+  daysWorkedOther: 0,
   thirtyPercentRuling: false,
   socialContributions: 0,
   aanvullendPensioen: 0,
   dienstencheques: 0,
   roerendeVoorheffing: 0,
+  withheldTaxNL: 0,
+  sickDays: 0,
 };
 
 export const mockNLResult: NLTaxResult = {


### PR DESCRIPTION
$(cat <<'EOF'
Closes #108

## Summary

- **New teal brand color** (`#0d9488`) replaces orange/gold as the global identity — professional and finance-adjacent without copying the blue/purple from other apps in the family
- **NL orange + BE gold demoted** to subtle per-tab left-border accents only (unchanged `bt-nl-accent` / `bt-be-accent` classes)
- **Light/dark/auto theme support** via Bootstrap 5.3 `data-bs-theme` attribute:
  - Default is `auto` — reads `prefers-color-scheme` via media query
  - Toggle button in navbar cycles: auto (⊙) → light (☀) → dark (🌙) → auto
  - Preference stored in `localStorage` under `bt-theme`
  - Inline script in `index.html` applies stored preference before first paint (no flash)
- **Light mode tokens** defined for surfaces, borders, text, and semantic colors
- Focus rings, form controls, checkboxes, and primary buttons updated to use teal brand

## Test plan

- [ ] App renders correctly in dark mode (default for new visitors)
- [ ] App renders correctly in light mode
- [ ] Auto mode follows OS setting (change OS appearance → app updates)
- [ ] Toggle button in navbar cycles through all three states; icon reflects current mode (sun / moon / circle-half)
- [ ] On reload, remembered preference is restored
- [ ] NL tab pane shows orange left-border accent; BE tab pane shows gold — no orange/gold elsewhere in the UI
- [ ] All 119 tests pass (`pnpm test`)

https://claude.ai/code/session_012kxrR1XsNCBu3goZZg7gJ1
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012kxrR1XsNCBu3goZZg7gJ1)_