### PR TITLE
Add Zod: replace sanitizeInputs with TaxInputSchema

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,12 @@
     />
     <script>
       (function () {
-        var stored = localStorage.getItem("bt-theme");
+        var stored;
+        try {
+          stored = localStorage.getItem("bt-theme");
+        } catch (e) {
+          stored = null;
+        }
         var prefersDark =
           typeof window.matchMedia === "function" &&
           window.matchMedia("(prefers-color-scheme: dark)").matches;

--- a/messages/en.json
+++ b/messages/en.json
@@ -590,5 +590,8 @@
   "theme_toggle_label": "Theme",
   "theme_auto": "auto",
   "theme_light": "light",
-  "theme_dark": "dark"
+  "theme_dark": "dark",
+  "results_error_title": "Something went wrong",
+  "results_error_description": "The tax calculation encountered an unexpected error. Try adjusting your inputs.",
+  "results_error_details": "Technical details"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -590,5 +590,8 @@
   "theme_toggle_label": "Thema",
   "theme_auto": "auto",
   "theme_light": "licht",
-  "theme_dark": "donker"
+  "theme_dark": "donker",
+  "results_error_title": "Er ging iets mis",
+  "results_error_description": "De belastingberekening is vastgelopen. Probeer je gegevens aan te passen.",
+  "results_error_details": "Technische details"
 }

--- a/package.json
+++ b/package.json
@@ -34,12 +34,15 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
+    "@tanstack/react-form": "^1.33.0",
     "@tanstack/react-router": "^1.170.9",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
+    "clsx": "^2.1.1",
     "react": "^19.2.6",
-    "react-bootstrap": "^2.10.10",
+    "react-bootstrap": "3.0.0-beta.5",
     "react-dom": "^19.2.6",
+    "react-error-boundary": "^6.1.2",
     "recharts": "^3.8.1",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react": "^19.2.6",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.6",
-    "recharts": "^3.8.1"
+    "recharts": "^3.8.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@inlang/paraglide-js": "^2.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@inlang/paraglide-js':
         specifier: ^2.18.1
@@ -1512,6 +1515,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
@@ -2688,3 +2694,5 @@ snapshots:
       stackback: 0.0.2
 
   ws@8.20.0: {}
+
+  zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
+      '@tanstack/react-form':
+        specifier: ^1.33.0
+        version: 1.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-router':
         specifier: ^1.170.9
         version: 1.170.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -20,15 +23,21 @@ importers:
       bootstrap-icons:
         specifier: ^1.13.1
         version: 1.13.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       react:
         specifier: ^19.2.6
         version: 19.2.6
       react-bootstrap:
-        specifier: ^2.10.10
-        version: 2.10.10(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 3.0.0-beta.5
+        version: 3.0.0-beta.5(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
+      react-error-boundary:
+        specifier: ^6.1.2
+        version: 6.1.2(react@19.2.6)
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1)
@@ -450,12 +459,6 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
-  '@react-aria/ssr@3.9.10':
-    resolution: {integrity: sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==}
-    engines: {node: '>= 12'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   '@reduxjs/toolkit@2.12.0':
     resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
     peerDependencies:
@@ -467,21 +470,16 @@ packages:
       react-redux:
         optional: true
 
-  '@restart/hooks@0.4.16':
-    resolution: {integrity: sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==}
+  '@restart/hooks@0.6.2':
+    resolution: {integrity: sha512-0QzYBe1raty/ULcuyTk0ZdLf+e//4n/f39hDPt5JYZW5kSbHEAgnZhLpWErCKEYSzi14oVBSbNsllnJmWlloBg==}
     peerDependencies:
       react: '>=16.8.0'
 
-  '@restart/hooks@0.5.1':
-    resolution: {integrity: sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==}
+  '@restart/ui@2.0.0-beta.12':
+    resolution: {integrity: sha512-C8M1Ecgsemp4kjUOmsxafQOpoetcrROGtGAW9sHAQ71wdNbO4xMk4QdunmxZxTrsHypPJh3wNmlaxgBKhlrz2g==}
     peerDependencies:
-      react: '>=16.8.0'
-
-  '@restart/ui@1.9.4':
-    resolution: {integrity: sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==}
-    peerDependencies:
-      react: '>=16.14.0'
-      react-dom: '>=16.14.0'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   '@rolldown/binding-android-arm64@1.0.2':
     resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
@@ -594,12 +592,30 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
-  '@swc/helpers@0.5.19':
-    resolution: {integrity: sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==}
+  '@tanstack/devtools-event-client@0.4.3':
+    resolution: {integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@tanstack/form-core@1.33.0':
+    resolution: {integrity: sha512-AV4Pw9Dk4orFsuPBcDssfWMJFs+yMYBae7zZ4oTqrCf4ftNGQKxvrQRZeqKHG6A4TkiLeSvf2kzIjcVkrW7E6w==}
 
   '@tanstack/history@1.162.0':
     resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
     engines: {node: '>=20.19'}
+
+  '@tanstack/pacer-lite@0.1.1':
+    resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
+    engines: {node: '>=18'}
+
+  '@tanstack/react-form@1.33.0':
+    resolution: {integrity: sha512-unaee+VS4MvKo+s1dmgGUXI4902VeAhuaUbKsQbhFe3MceOpB3JpAUGCDpyzjQPXVFkFY0COKfLrUNX2XZYW4g==}
+    peerDependencies:
+      '@tanstack/react-start': '*'
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@tanstack/react-start':
+        optional: true
 
   '@tanstack/react-router@1.170.9':
     resolution: {integrity: sha512-rXXztp6GyXFwResQR0jdvkf52wy/sAQqze3OR08+8uNM7nHir1P46qBrwg2TL5EEtX+0WUho4BZ/nMpAgQVB6A==}
@@ -607,6 +623,12 @@ packages:
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.11.0':
+    resolution: {integrity: sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@tanstack/react-store@0.9.3':
     resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
@@ -617,6 +639,9 @@ packages:
   '@tanstack/router-core@1.171.7':
     resolution: {integrity: sha512-AboyQD0OPIu0adJi6HeCupTU9Wx7zr4q4ceJYQdBL3mLH18m4M57XXdzJdtzOg/twl8DtWej0RGJ12ma8CV1iQ==}
     engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.11.0':
+    resolution: {integrity: sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw==}
 
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
@@ -688,9 +713,6 @@ packages:
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
-
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -818,9 +840,6 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
-  classnames@2.5.1:
-    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
-
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -923,6 +942,9 @@ packages:
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dom-helpers@6.0.1:
+    resolution: {integrity: sha512-IKySryuFwseGkrCA/pIqlwUPOD50w1Lj/B2Yief3vBOP18k5y4t+hTqKh55gULDVeJMRitcozve+g/wVFf4sFQ==}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -1196,20 +1218,15 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
-  prop-types-extra@1.1.1:
-    resolution: {integrity: sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==}
-    peerDependencies:
-      react: '>=0.14.0'
-
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  react-bootstrap@2.10.10:
-    resolution: {integrity: sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==}
+  react-bootstrap@3.0.0-beta.5:
+    resolution: {integrity: sha512-/hlkMPx8DVl3qhYORYDuQ1xxktvYP1dHTKd7OHGqROugHUI3kIgl4nuwx5XT3+WQpOnOmHN2R3hrtgVP72aoNw==}
     peerDependencies:
-      '@types/react': '>=16.14.8'
-      react: '>=16.14.0'
-      react-dom: '>=16.14.0'
+      '@types/react': '>=18.3.12'
+      react: '>=18.3.1'
+      react-dom: '>=18.3.1'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1219,14 +1236,16 @@ packages:
     peerDependencies:
       react: ^19.2.6
 
+  react-error-boundary@6.1.2:
+    resolution: {integrity: sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
-
-  react-lifecycles-compat@3.0.4:
-    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
 
   react-redux@9.3.0:
     resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
@@ -1372,13 +1391,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  uncontrollable@7.2.1:
-    resolution: {integrity: sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==}
-    peerDependencies:
-      react: '>=15.0.0'
-
-  uncontrollable@8.0.4:
-    resolution: {integrity: sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==}
+  uncontrollable@9.0.0:
+    resolution: {integrity: sha512-wPScOFmvRkHdvebf7qNPn9Wog9B1TL8Dqcx0Vecz6HYTKFKMfGKP6MJHTjiKL8kwd8KTW3YfIUke7pmRDtkcRQ==}
     peerDependencies:
       react: '>=16.14.0'
 
@@ -1766,11 +1780,6 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@react-aria/ssr@3.9.10(react@19.2.6)':
-    dependencies:
-      '@swc/helpers': 0.5.19
-      react: 19.2.6
-
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1))(react@19.2.6)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1783,28 +1792,22 @@ snapshots:
       react: 19.2.6
       react-redux: 9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1)
 
-  '@restart/hooks@0.4.16(react@19.2.6)':
+  '@restart/hooks@0.6.2(react@19.2.6)':
     dependencies:
       dequal: 2.0.3
       react: 19.2.6
 
-  '@restart/hooks@0.5.1(react@19.2.6)':
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.6
-
-  '@restart/ui@1.9.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@restart/ui@2.0.0-beta.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@popperjs/core': 2.11.8
-      '@react-aria/ssr': 3.9.10(react@19.2.6)
-      '@restart/hooks': 0.5.1(react@19.2.6)
+      '@restart/hooks': 0.6.2(react@19.2.6)
       '@types/warning': 3.0.4
       dequal: 2.0.3
-      dom-helpers: 5.2.1
+      dom-helpers: 6.0.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      uncontrollable: 8.0.4(react@19.2.6)
+      uncontrollable: 9.0.0(react@19.2.6)
       warning: 4.0.3
 
   '@rolldown/binding-android-arm64@1.0.2':
@@ -1866,11 +1869,25 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@swc/helpers@0.5.19':
+  '@tanstack/devtools-event-client@0.4.3': {}
+
+  '@tanstack/form-core@1.33.0':
     dependencies:
-      tslib: 2.8.1
+      '@tanstack/devtools-event-client': 0.4.3
+      '@tanstack/pacer-lite': 0.1.1
+      '@tanstack/store': 0.11.0
 
   '@tanstack/history@1.162.0': {}
+
+  '@tanstack/pacer-lite@0.1.1': {}
+
+  '@tanstack/react-form@1.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/form-core': 1.33.0
+      '@tanstack/react-store': 0.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+    transitivePeerDependencies:
+      - react-dom
 
   '@tanstack/react-router@1.170.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -1880,6 +1897,13 @@ snapshots:
       isbot: 5.1.40
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+
+  '@tanstack/react-store@0.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/store': 0.11.0
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
 
   '@tanstack/react-store@0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -1894,6 +1918,8 @@ snapshots:
       cookie-es: 3.1.1
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/store@0.11.0': {}
 
   '@tanstack/store@0.9.3': {}
 
@@ -1970,8 +1996,6 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
-
-  '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.15)':
     dependencies:
@@ -2098,8 +2122,6 @@ snapshots:
 
   chai@6.2.2: {}
 
-  classnames@2.5.1: {}
-
   clsx@2.1.1: {}
 
   commander@11.1.0: {}
@@ -2172,6 +2194,11 @@ snapshots:
   dom-accessibility-api@0.6.3: {}
 
   dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
+
+  dom-helpers@6.0.1:
     dependencies:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
@@ -2403,34 +2430,25 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  prop-types-extra@1.1.1(react@19.2.6):
-    dependencies:
-      react: 19.2.6
-      react-is: 16.13.1
-      warning: 4.0.3
-
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  react-bootstrap@2.10.10(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-bootstrap@3.0.0-beta.5(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@restart/hooks': 0.4.16(react@19.2.6)
-      '@restart/ui': 1.9.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@types/prop-types': 15.7.15
+      '@restart/hooks': 0.6.2(react@19.2.6)
+      '@restart/ui': 2.0.0-beta.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/react-transition-group': 4.4.12(@types/react@19.2.15)
-      classnames: 2.5.1
-      dom-helpers: 5.2.1
+      clsx: 2.1.1
+      dom-helpers: 6.0.1
       invariant: 2.2.4
-      prop-types: 15.8.1
-      prop-types-extra: 1.1.1(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-transition-group: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      uncontrollable: 7.2.1(react@19.2.6)
+      uncontrollable: 9.0.0(react@19.2.6)
       warning: 4.0.3
     optionalDependencies:
       '@types/react': 19.2.15
@@ -2440,11 +2458,13 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
+  react-error-boundary@6.1.2(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
-
-  react-lifecycles-compat@3.0.4: {}
 
   react-redux@9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1):
     dependencies:
@@ -2588,19 +2608,12 @@ snapshots:
 
   totalist@3.0.1: {}
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   typescript@6.0.3: {}
 
-  uncontrollable@7.2.1(react@19.2.6):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@types/react': 19.2.15
-      invariant: 2.2.4
-      react: 19.2.6
-      react-lifecycles-compat: 3.0.4
-
-  uncontrollable@8.0.4(react@19.2.6):
+  uncontrollable@9.0.0(react@19.2.6):
     dependencies:
       react: 19.2.6
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { Link } from "@tanstack/react-router";
+import { useForm, useStore } from "@tanstack/react-form";
 import { useEffect, useMemo, useState } from "react";
 import { Button, Col, Container, Nav, Navbar, Row, Tab } from "react-bootstrap";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "bootstrap-icons/font/bootstrap-icons.css";
 import "./styles.css";
@@ -14,7 +16,7 @@ import WFHRatioChart from "./components/WFHRatioChart";
 import { calculate } from "./tax";
 import type { TaxInputs } from "./tax/types";
 import { VALID_YEARS } from "./tax/constants";
-import { PersistedInputsSchema, type PersistedInputs } from "./tax/schema";
+import { TaxInputSchema, PersistedInputsSchema, type PersistedInputs } from "./tax/schema";
 import * as m from "./paraglide/messages.js";
 import { getLocale, setLocale } from "./paraglide/runtime.js";
 
@@ -85,8 +87,102 @@ function applyTheme(theme: Theme) {
 
 const THEME_CYCLE: Theme[] = ["auto", "light", "dark"];
 
+interface ResultsTabsProps {
+  inputs: TaxInputs;
+  onResetInputs: () => void;
+}
+
+function ResultsTabs({ inputs, onResetInputs }: ResultsTabsProps) {
+  const result = useMemo(() => calculate(inputs), [inputs]);
+  const comparisonResults = useMemo(
+    () =>
+      VALID_YEARS.map((year) => ({
+        year,
+        result: year === inputs.year ? result : calculate({ ...inputs, year }),
+      })),
+    [inputs, result],
+  );
+
+  return (
+    <Tab.Container defaultActiveKey="summary">
+      <Nav variant="tabs" className="mb-3">
+        <Nav.Item>
+          <Nav.Link eventKey="summary" aria-label={m.tabs_summary()}>
+            <i className="bi bi-pie-chart-fill me-1" />
+            {m.tabs_summary()}
+          </Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="nl" aria-label={m.tabs_nl()}>
+            🇳🇱 {m.tabs_nl()}
+          </Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="be" aria-label={m.tabs_be()}>
+            🇧🇪 {m.tabs_be()}
+          </Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="years" aria-label={m.tabs_year_comparison()}>
+            <i className="bi bi-bar-chart-line-fill me-1" />
+            {m.tabs_year_comparison()}
+          </Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="wfh" aria-label={m.tabs_wfh_ratio()}>
+            <i className="bi bi-house-fill me-1" />
+            {m.tabs_wfh_ratio()}
+          </Nav.Link>
+        </Nav.Item>
+      </Nav>
+
+      <Tab.Content>
+        <Tab.Pane eventKey="summary">
+          <SummaryResult result={result} onResetInputs={onResetInputs} />
+        </Tab.Pane>
+        <Tab.Pane eventKey="nl" className="bt-nl-accent">
+          <NLResult
+            result={result.nl}
+            withheldTaxNL={inputs.withheldTaxNL}
+            thirtyPercentRuling={inputs.thirtyPercentRuling}
+          />
+        </Tab.Pane>
+        <Tab.Pane eventKey="be" className="bt-be-accent">
+          <BEResult result={result.be} residentCountry={inputs.residentCountry} />
+        </Tab.Pane>
+        <Tab.Pane eventKey="years">
+          <MultiYearComparison rows={comparisonResults} activeYear={inputs.year} />
+        </Tab.Pane>
+        <Tab.Pane eventKey="wfh">
+          <WFHRatioChart inputs={inputs} />
+        </Tab.Pane>
+      </Tab.Content>
+    </Tab.Container>
+  );
+}
+
+function ResultsErrorFallback({ error }: FallbackProps) {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    <div className="p-4 text-center">
+      <i className="bi bi-exclamation-triangle-fill text-warning fs-2 mb-3 d-block" />
+      <h5>{m.results_error_title()}</h5>
+      <p className="text-muted small mb-3">{m.results_error_description()}</p>
+      <details className="text-start small text-muted">
+        <summary className="mb-1">{m.results_error_details()}</summary>
+        <pre className="border rounded p-2 small overflow-auto">{message}</pre>
+      </details>
+    </div>
+  );
+}
+
 export default function App() {
-  const [inputs, setInputs] = useState<TaxInputs>(loadInitialInputs);
+  const form = useForm({ defaultValues: loadInitialInputs() });
+  const rawValues = useStore(form.store, (s) => s.values);
+  const inputs = useMemo(() => {
+    const parsed = TaxInputSchema.safeParse(rawValues);
+    return parsed.success ? parsed.data : DEFAULT_INPUTS;
+  }, [rawValues]);
   const [locale, setCurrentLocale] = useState(getLocale());
   const [theme, setTheme] = useState<Theme>(loadTheme);
   const nextLangLabel = locale === "en" ? m.lang_nl() : m.lang_en();
@@ -102,16 +198,6 @@ export default function App() {
       return () => mq.removeEventListener("change", handler);
     }
   }, [theme]);
-
-  const result = useMemo(() => calculate(inputs), [inputs]);
-  const comparisonResults = useMemo(
-    () =>
-      VALID_YEARS.map((year) => ({
-        year,
-        result: year === inputs.year ? result : calculate({ ...inputs, year }),
-      })),
-    [inputs, result],
-  );
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(toPersistedInputs(inputs)));
@@ -166,65 +252,14 @@ export default function App() {
         <Row className="g-4 bt-main-row">
           {/* ── Left column: inputs ────────────────────────────── */}
           <Col lg={5}>
-            <InputPanel inputs={inputs} onChange={setInputs} />
+            <InputPanel form={form} />
           </Col>
 
           {/* ── Right column: results ──────────────────────────── */}
           <Col lg={7}>
-            <Tab.Container defaultActiveKey="summary">
-              <Nav variant="tabs" className="mb-3">
-                <Nav.Item>
-                  <Nav.Link eventKey="summary" aria-label={m.tabs_summary()}>
-                    <i className="bi bi-pie-chart-fill me-1" />
-                    {m.tabs_summary()}
-                  </Nav.Link>
-                </Nav.Item>
-                <Nav.Item>
-                  <Nav.Link eventKey="nl" aria-label={m.tabs_nl()}>
-                    🇳🇱 {m.tabs_nl()}
-                  </Nav.Link>
-                </Nav.Item>
-                <Nav.Item>
-                  <Nav.Link eventKey="be" aria-label={m.tabs_be()}>
-                    🇧🇪 {m.tabs_be()}
-                  </Nav.Link>
-                </Nav.Item>
-                <Nav.Item>
-                  <Nav.Link eventKey="years" aria-label={m.tabs_year_comparison()}>
-                    <i className="bi bi-bar-chart-line-fill me-1" />
-                    {m.tabs_year_comparison()}
-                  </Nav.Link>
-                </Nav.Item>
-                <Nav.Item>
-                  <Nav.Link eventKey="wfh" aria-label={m.tabs_wfh_ratio()}>
-                    <i className="bi bi-house-fill me-1" />
-                    {m.tabs_wfh_ratio()}
-                  </Nav.Link>
-                </Nav.Item>
-              </Nav>
-
-              <Tab.Content>
-                <Tab.Pane eventKey="summary">
-                  <SummaryResult result={result} onResetInputs={() => setInputs(DEFAULT_INPUTS)} />
-                </Tab.Pane>
-                <Tab.Pane eventKey="nl" className="bt-nl-accent">
-                  <NLResult
-                    result={result.nl}
-                    withheldTaxNL={inputs.withheldTaxNL}
-                    thirtyPercentRuling={inputs.thirtyPercentRuling}
-                  />
-                </Tab.Pane>
-                <Tab.Pane eventKey="be" className="bt-be-accent">
-                  <BEResult result={result.be} residentCountry={inputs.residentCountry} />
-                </Tab.Pane>
-                <Tab.Pane eventKey="years">
-                  <MultiYearComparison rows={comparisonResults} activeYear={inputs.year} />
-                </Tab.Pane>
-                <Tab.Pane eventKey="wfh">
-                  <WFHRatioChart inputs={inputs} />
-                </Tab.Pane>
-              </Tab.Content>
-            </Tab.Container>
+            <ErrorBoundary FallbackComponent={ResultsErrorFallback}>
+              <ResultsTabs inputs={inputs} onResetInputs={() => form.reset(DEFAULT_INPUTS)} />
+            </ErrorBoundary>
           </Col>
         </Row>
       </Container>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,26 +13,12 @@ import MultiYearComparison from "./components/MultiYearComparison";
 import WFHRatioChart from "./components/WFHRatioChart";
 import { calculate } from "./tax";
 import type { TaxInputs } from "./tax/types";
-import {
-  VALID_BELGIAN_REGIONS,
-  VALID_CIVIL_STATUSES,
-  VALID_RESIDENT_COUNTRIES,
-  VALID_YEARS,
-} from "./tax/constants";
+import { VALID_YEARS } from "./tax/constants";
+import { PersistedInputsSchema, type PersistedInputs } from "./tax/schema";
 import * as m from "./paraglide/messages.js";
 import { getLocale, setLocale } from "./paraglide/runtime.js";
 
-type TaxInputsWithRequiredBEDeductions = TaxInputs & {
-  socialContributions: number;
-  aanvullendPensioen: number;
-  dienstencheques: number;
-  roerendeVoorheffing: number;
-  withheldTaxNL: number;
-  daysWorkedOther: number;
-  sickDays: number;
-};
-
-const DEFAULT_INPUTS: TaxInputsWithRequiredBEDeductions = {
+const DEFAULT_INPUTS: TaxInputs = {
   year: 2025,
   residentCountry: "BE",
   civilStatus: "single",
@@ -55,110 +41,15 @@ const DEFAULT_INPUTS: TaxInputsWithRequiredBEDeductions = {
 
 const STORAGE_KEY = "grensarbeider-tax-inputs-v1";
 
-function sanitizeInputs(raw: unknown): TaxInputs {
-  if (!raw || typeof raw !== "object") {
-    return DEFAULT_INPUTS;
-  }
-
-  const input = raw as Partial<TaxInputs>;
-
-  const isOneOf = <T,>(value: unknown, options: readonly T[]): value is T =>
-    options.includes(value as T);
-
-  const sanitizeNonNegative = (value: unknown, defaultValue: number): number =>
-    Number.isFinite(value) ? Math.max(0, Number(value)) : defaultValue;
-
-  return {
-    year: isOneOf(input.year, VALID_YEARS) ? input.year : DEFAULT_INPUTS.year,
-    residentCountry: isOneOf(input.residentCountry, VALID_RESIDENT_COUNTRIES)
-      ? input.residentCountry
-      : DEFAULT_INPUTS.residentCountry,
-    civilStatus: isOneOf(input.civilStatus, VALID_CIVIL_STATUSES)
-      ? input.civilStatus
-      : DEFAULT_INPUTS.civilStatus,
-    dependentChildren: Number.isFinite(input.dependentChildren)
-      ? Math.min(10, Math.max(0, Number(input.dependentChildren)))
-      : DEFAULT_INPUTS.dependentChildren,
-    belowAOWAge:
-      typeof input.belowAOWAge === "boolean" ? input.belowAOWAge : DEFAULT_INPUTS.belowAOWAge,
-    belgianRegion: isOneOf(input.belgianRegion, VALID_BELGIAN_REGIONS)
-      ? input.belgianRegion
-      : DEFAULT_INPUTS.belgianRegion,
-    communalTaxRate: Number.isFinite(input.communalTaxRate)
-      ? Math.min(15, Math.max(0, Number(input.communalTaxRate)))
-      : DEFAULT_INPUTS.communalTaxRate,
-    grossSalary: Number.isFinite(input.grossSalary)
-      ? Math.max(0, Number(input.grossSalary))
-      : DEFAULT_INPUTS.grossSalary,
-    daysWorkedNL: Number.isFinite(input.daysWorkedNL)
-      ? Math.max(0, Number(input.daysWorkedNL))
-      : DEFAULT_INPUTS.daysWorkedNL,
-    daysWorkedBE: Number.isFinite(input.daysWorkedBE)
-      ? Math.max(0, Number(input.daysWorkedBE))
-      : DEFAULT_INPUTS.daysWorkedBE,
-    daysWorkedOther: sanitizeNonNegative(input.daysWorkedOther, DEFAULT_INPUTS.daysWorkedOther),
-    thirtyPercentRuling:
-      typeof input.thirtyPercentRuling === "boolean"
-        ? input.thirtyPercentRuling
-        : DEFAULT_INPUTS.thirtyPercentRuling,
-    socialContributions: sanitizeNonNegative(
-      input.socialContributions,
-      DEFAULT_INPUTS.socialContributions,
-    ),
-    aanvullendPensioen: sanitizeNonNegative(
-      input.aanvullendPensioen,
-      DEFAULT_INPUTS.aanvullendPensioen,
-    ),
-    dienstencheques: sanitizeNonNegative(input.dienstencheques, DEFAULT_INPUTS.dienstencheques),
-    roerendeVoorheffing: sanitizeNonNegative(
-      input.roerendeVoorheffing,
-      DEFAULT_INPUTS.roerendeVoorheffing,
-    ),
-    withheldTaxNL: sanitizeNonNegative(input.withheldTaxNL, DEFAULT_INPUTS.withheldTaxNL),
-    sickDays: sanitizeNonNegative(input.sickDays, DEFAULT_INPUTS.sickDays),
-  };
-}
-
-type PersistedInputs = Pick<
-  TaxInputs,
-  | "year"
-  | "residentCountry"
-  | "civilStatus"
-  | "dependentChildren"
-  | "belowAOWAge"
-  | "belgianRegion"
-  | "communalTaxRate"
-  | "thirtyPercentRuling"
->;
-
 function toPersistedInputs(inputs: TaxInputs): PersistedInputs {
-  return {
-    year: inputs.year,
-    residentCountry: inputs.residentCountry,
-    civilStatus: inputs.civilStatus,
-    dependentChildren: inputs.dependentChildren,
-    belowAOWAge: inputs.belowAOWAge,
-    belgianRegion: inputs.belgianRegion,
-    communalTaxRate: inputs.communalTaxRate,
-    thirtyPercentRuling: inputs.thirtyPercentRuling,
-  };
+  return PersistedInputsSchema.parse(inputs);
 }
 
 function mergeWithDefaults(raw: unknown): TaxInputs {
-  const sanitized = sanitizeInputs(raw);
-  return {
-    ...sanitized,
-    grossSalary: DEFAULT_INPUTS.grossSalary,
-    daysWorkedNL: DEFAULT_INPUTS.daysWorkedNL,
-    daysWorkedBE: DEFAULT_INPUTS.daysWorkedBE,
-    daysWorkedOther: DEFAULT_INPUTS.daysWorkedOther,
-    sickDays: DEFAULT_INPUTS.sickDays,
-    socialContributions: DEFAULT_INPUTS.socialContributions,
-    aanvullendPensioen: DEFAULT_INPUTS.aanvullendPensioen,
-    dienstencheques: DEFAULT_INPUTS.dienstencheques,
-    roerendeVoorheffing: DEFAULT_INPUTS.roerendeVoorheffing,
-    withheldTaxNL: DEFAULT_INPUTS.withheldTaxNL,
-  };
+  if (!raw || typeof raw !== "object") {
+    return DEFAULT_INPUTS;
+  }
+  return { ...DEFAULT_INPUTS, ...PersistedInputsSchema.parse(raw) };
 }
 
 function loadInitialInputs(): TaxInputs {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,10 +46,8 @@ function toPersistedInputs(inputs: TaxInputs): PersistedInputs {
 }
 
 function mergeWithDefaults(raw: unknown): TaxInputs {
-  if (!raw || typeof raw !== "object") {
-    return DEFAULT_INPUTS;
-  }
-  return { ...DEFAULT_INPUTS, ...PersistedInputsSchema.parse(raw) };
+  const parsed = PersistedInputsSchema.safeParse(raw);
+  return parsed.success ? { ...DEFAULT_INPUTS, ...parsed.data } : DEFAULT_INPUTS;
 }
 
 function loadInitialInputs(): TaxInputs {

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -1,4 +1,8 @@
 import { useState } from "react";
+import { useStore } from "@tanstack/react-form";
+import clsx from "clsx";
+import type { ReactFormExtendedApi } from "@tanstack/react-form";
+import { z } from "zod";
 import { Accordion, Alert, Badge, Button, Col, Form, Row } from "react-bootstrap";
 import {
   VALID_YEARS,
@@ -10,9 +14,11 @@ import type { TaxInputs } from "../tax/types";
 import { getMaxDaysInYear, getTotalWorkdays } from "../tax/workdays";
 import * as m from "../paraglide/messages.js";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TaxFormApi = ReactFormExtendedApi<TaxInputs, any, any, any, any, any, any, any, any, any, any, any>;
+
 interface Props {
-  inputs: TaxInputs;
-  onChange: (updated: TaxInputs) => void;
+  form: TaxFormApi;
 }
 
 type BelgianDeductionKey =
@@ -21,29 +27,37 @@ type BelgianDeductionKey =
   | "dienstencheques"
   | "roerendeVoorheffing";
 
-const clampNumber = (value: string, min = 0, max = Number.POSITIVE_INFINITY) =>
-  Math.min(max, Math.max(min, Number(value) || 0));
+function fieldError(errors: unknown[]): string | undefined {
+  if (!errors.length) return undefined;
+  const msgs = errors.flatMap((e) => {
+    if (Array.isArray(e)) return e.map((i) => (i as { message?: string })?.message ?? String(i));
+    if (e && typeof e === "object" && "message" in e)
+      return [(e as { message: unknown }).message as string];
+    return [String(e)];
+  });
+  return msgs.filter(Boolean).join(" ") || undefined;
+}
 
-export default function InputPanel({ inputs, onChange }: Props) {
+export default function InputPanel({ form }: Props) {
   const [showFormulas, setShowFormulas] = useState(false);
+  const values = useStore(form.store, (s) => s.values);
 
-  function set<K extends keyof TaxInputs>(key: K, value: TaxInputs[K]) {
-    onChange({ ...inputs, [key]: value });
-  }
-
-  const totalWorkdays = getTotalWorkdays(inputs);
-  const maxWorkdaysInYear = getMaxDaysInYear(inputs.year);
-  const beFraction = totalWorkdays > 0 ? inputs.daysWorkedBE / totalWorkdays : 0;
+  const totalWorkdays = getTotalWorkdays(values);
+  const maxWorkdaysInYear = getMaxDaysInYear(values.year);
+  const beFraction = totalWorkdays > 0 ? values.daysWorkedBE / totalWorkdays : 0;
 
   const nlBarW =
-    maxWorkdaysInYear > 0 ? Math.min(100, (inputs.daysWorkedNL / maxWorkdaysInYear) * 100) : 0;
+    maxWorkdaysInYear > 0 ? Math.min(100, (values.daysWorkedNL / maxWorkdaysInYear) * 100) : 0;
   const beBarW =
     maxWorkdaysInYear > 0
-      ? Math.min(100 - nlBarW, (inputs.daysWorkedBE / maxWorkdaysInYear) * 100)
+      ? Math.min(100 - nlBarW, (values.daysWorkedBE / maxWorkdaysInYear) * 100)
       : 0;
   const otherBarW =
     maxWorkdaysInYear > 0
-      ? Math.min(100 - nlBarW - beBarW, ((inputs.daysWorkedOther ?? 0) / maxWorkdaysInYear) * 100)
+      ? Math.min(
+          100 - nlBarW - beBarW,
+          ((values.daysWorkedOther ?? 0) / maxWorkdaysInYear) * 100,
+        )
       : 0;
 
   return (
@@ -56,138 +70,200 @@ export default function InputPanel({ inputs, onChange }: Props) {
         </Accordion.Header>
         <Accordion.Body>
           <Row className="g-3">
-            <Col xs={12} sm={6}>
-              <Form.Label>{m.input_tax_year()}</Form.Label>
-              <Form.Select
-                value={inputs.year}
-                onChange={(e) => set("year", Number(e.target.value) as TaxInputs["year"])}
-              >
-                {VALID_YEARS.map((y) => (
-                  <option key={y} value={y}>
-                    {y}
-                  </option>
-                ))}
-              </Form.Select>
-            </Col>
+            <form.Field name="year">
+              {(field) => (
+                <Col xs={12} sm={6}>
+                  <Form.Label>{m.input_tax_year()}</Form.Label>
+                  <Form.Select
+                    value={field.state.value}
+                    onChange={(e) =>
+                      field.handleChange(Number(e.target.value) as TaxInputs["year"])
+                    }
+                    onBlur={field.handleBlur}
+                  >
+                    {VALID_YEARS.map((y) => (
+                      <option key={y} value={y}>
+                        {y}
+                      </option>
+                    ))}
+                  </Form.Select>
+                </Col>
+              )}
+            </form.Field>
 
             {VALID_RESIDENT_COUNTRIES.length > 1 && (
-              <Col xs={12} sm={6}>
-                <Form.Label>{m.input_resident_country()}</Form.Label>
-                <Form.Select
-                  value={inputs.residentCountry}
-                  onChange={(e) =>
-                    set("residentCountry", e.target.value as TaxInputs["residentCountry"])
-                  }
-                >
-                  {(VALID_RESIDENT_COUNTRIES as readonly string[]).includes("BE") && (
-                    <option value="BE">🇧🇪 {m.input_resident_country_be()}</option>
-                  )}
-                  {(VALID_RESIDENT_COUNTRIES as readonly string[]).includes("NL") && (
-                    <option value="NL">🇳🇱 {m.input_resident_country_nl()}</option>
-                  )}
-                </Form.Select>
-              </Col>
-            )}
-
-            {VALID_CIVIL_STATUSES.length > 1 && (
-              <Col xs={12} sm={6}>
-                <Form.Label>
-                  {m.input_civil_status()}{" "}
-                  <Badge
-                    bg="secondary"
-                    className="ms-1 fw-normal"
-                    aria-label={m.input_civil_status_not_used()}
-                  >
-                    {m.input_civil_status_not_used()}
-                  </Badge>
-                </Form.Label>
-                <Form.Select
-                  value={inputs.civilStatus}
-                  onChange={(e) => set("civilStatus", e.target.value as TaxInputs["civilStatus"])}
-                >
-                  {(VALID_CIVIL_STATUSES as readonly string[]).includes("single") && (
-                    <option value="single">{m.input_civil_status_single()}</option>
-                  )}
-                  {(VALID_CIVIL_STATUSES as readonly string[]).includes("married") && (
-                    <option value="married">{m.input_civil_status_married()}</option>
-                  )}
-                </Form.Select>
-              </Col>
-            )}
-
-            <Col xs={12} sm={6}>
-              <Form.Label>{m.input_dependents()}</Form.Label>
-              <Form.Control
-                type="number"
-                min={0}
-                max={10}
-                value={inputs.dependentChildren}
-                onChange={(e) => set("dependentChildren", clampNumber(e.target.value, 0, 10))}
-              />
-            </Col>
-
-            <Col xs={12}>
-              <Form.Check
-                id="aow-age"
-                label={m.input_below_aow_age()}
-                checked={inputs.belowAOWAge}
-                onChange={(e) => set("belowAOWAge", e.target.checked)}
-              />
-            </Col>
-
-            {inputs.residentCountry === "BE" && (
-              <>
-                {VALID_BELGIAN_REGIONS.length > 1 && (
+              <form.Field name="residentCountry">
+                {(field) => (
                   <Col xs={12} sm={6}>
-                    <Form.Label>
-                      {m.input_belgian_region()}{" "}
-                      <Badge
-                        bg="secondary"
-                        className="ms-1 fw-normal"
-                        aria-label={m.input_belgian_region_not_used()}
-                      >
-                        {m.input_belgian_region_not_used()}
-                      </Badge>
-                    </Form.Label>
+                    <Form.Label>{m.input_resident_country()}</Form.Label>
                     <Form.Select
-                      value={inputs.belgianRegion}
+                      value={field.state.value}
                       onChange={(e) =>
-                        set("belgianRegion", e.target.value as TaxInputs["belgianRegion"])
+                        field.handleChange(e.target.value as TaxInputs["residentCountry"])
                       }
+                      onBlur={field.handleBlur}
                     >
-                      {(VALID_BELGIAN_REGIONS as readonly string[]).includes("flemish") && (
-                        <option value="flemish">{m.input_belgian_region_flemish()}</option>
+                      {(VALID_RESIDENT_COUNTRIES as readonly string[]).includes("BE") && (
+                        <option value="BE">🇧🇪 {m.input_resident_country_be()}</option>
                       )}
-                      {(VALID_BELGIAN_REGIONS as readonly string[]).includes("walloon") && (
-                        <option value="walloon">{m.input_belgian_region_walloon()}</option>
-                      )}
-                      {(VALID_BELGIAN_REGIONS as readonly string[]).includes("brussels") && (
-                        <option value="brussels">{m.input_belgian_region_brussels()}</option>
+                      {(VALID_RESIDENT_COUNTRIES as readonly string[]).includes("NL") && (
+                        <option value="NL">🇳🇱 {m.input_resident_country_nl()}</option>
                       )}
                     </Form.Select>
                   </Col>
                 )}
+              </form.Field>
+            )}
 
-                <Col xs={12} sm={6}>
-                  <Form.Label>
-                    {m.input_municipal_tax()}{" "}
-                    <Badge bg="secondary" className="ms-1">
-                      %
-                    </Badge>
-                  </Form.Label>
-                  <Form.Control
-                    type="number"
-                    min={0}
-                    max={15}
-                    step={0.1}
-                    value={inputs.communalTaxRate}
-                    onChange={(e) => set("communalTaxRate", clampNumber(e.target.value, 0, 15))}
-                    aria-describedby="communal-tax-hint"
+            {VALID_CIVIL_STATUSES.length > 1 && (
+              <form.Field name="civilStatus">
+                {(field) => (
+                  <Col xs={12} sm={6}>
+                    <Form.Label>
+                      {m.input_civil_status()}{" "}
+                      <Badge
+                        bg="secondary"
+                        className="ms-1 fw-normal"
+                        aria-label={m.input_civil_status_not_used()}
+                      >
+                        {m.input_civil_status_not_used()}
+                      </Badge>
+                    </Form.Label>
+                    <Form.Select
+                      value={field.state.value}
+                      onChange={(e) =>
+                        field.handleChange(e.target.value as TaxInputs["civilStatus"])
+                      }
+                      onBlur={field.handleBlur}
+                    >
+                      {(VALID_CIVIL_STATUSES as readonly string[]).includes("single") && (
+                        <option value="single">{m.input_civil_status_single()}</option>
+                      )}
+                      {(VALID_CIVIL_STATUSES as readonly string[]).includes("married") && (
+                        <option value="married">{m.input_civil_status_married()}</option>
+                      )}
+                    </Form.Select>
+                  </Col>
+                )}
+              </form.Field>
+            )}
+
+            <form.Field
+              name="dependentChildren"
+              validators={{ onChange: z.number().int().min(0).max(10) }}
+            >
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12} sm={6}>
+                    <Form.Label>{m.input_dependents()}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min={0}
+                      max={10}
+                      value={field.state.value}
+                      onChange={(e) => {
+                        const n = (e.target as HTMLInputElement).valueAsNumber;
+                        field.handleChange(Number.isNaN(n) ? 0 : n);
+                      }}
+                      onBlur={field.handleBlur}
+                      isInvalid={!!err}
+                    />
+                    {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                  </Col>
+                );
+              }}
+            </form.Field>
+
+            <form.Field name="belowAOWAge">
+              {(field) => (
+                <Col xs={12}>
+                  <Form.Check
+                    id="aow-age"
+                    label={m.input_below_aow_age()}
+                    checked={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.checked)}
                   />
-                  <Form.Text id="communal-tax-hint" className="text-muted">
-                    {m.input_municipal_tax_hint()}
-                  </Form.Text>
                 </Col>
+              )}
+            </form.Field>
+
+            {values.residentCountry === "BE" && (
+              <>
+                {VALID_BELGIAN_REGIONS.length > 1 && (
+                  <form.Field name="belgianRegion">
+                    {(field) => (
+                      <Col xs={12} sm={6}>
+                        <Form.Label>
+                          {m.input_belgian_region()}{" "}
+                          <Badge
+                            bg="secondary"
+                            className="ms-1 fw-normal"
+                            aria-label={m.input_belgian_region_not_used()}
+                          >
+                            {m.input_belgian_region_not_used()}
+                          </Badge>
+                        </Form.Label>
+                        <Form.Select
+                          value={field.state.value}
+                          onChange={(e) =>
+                            field.handleChange(e.target.value as TaxInputs["belgianRegion"])
+                          }
+                          onBlur={field.handleBlur}
+                        >
+                          {(VALID_BELGIAN_REGIONS as readonly string[]).includes("flemish") && (
+                            <option value="flemish">{m.input_belgian_region_flemish()}</option>
+                          )}
+                          {(VALID_BELGIAN_REGIONS as readonly string[]).includes("walloon") && (
+                            <option value="walloon">{m.input_belgian_region_walloon()}</option>
+                          )}
+                          {(VALID_BELGIAN_REGIONS as readonly string[]).includes("brussels") && (
+                            <option value="brussels">{m.input_belgian_region_brussels()}</option>
+                          )}
+                        </Form.Select>
+                      </Col>
+                    )}
+                  </form.Field>
+                )}
+
+                <form.Field
+                  name="communalTaxRate"
+                  validators={{ onChange: z.number().min(0).max(15) }}
+                >
+                  {(field) => {
+                    const err = fieldError(field.state.meta.errors as unknown[]);
+                    return (
+                      <Col xs={12} sm={6}>
+                        <Form.Label>
+                          {m.input_municipal_tax()}{" "}
+                          <Badge bg="secondary" className="ms-1">
+                            %
+                          </Badge>
+                        </Form.Label>
+                        <Form.Control
+                          type="number"
+                          min={0}
+                          max={15}
+                          step={0.1}
+                          value={field.state.value}
+                          onChange={(e) => {
+                            const n = (e.target as HTMLInputElement).valueAsNumber;
+                            field.handleChange(Number.isNaN(n) ? 0 : n);
+                          }}
+                          onBlur={field.handleBlur}
+                          isInvalid={!!err}
+                          aria-describedby="communal-tax-hint"
+                        />
+                        <Form.Text id="communal-tax-hint" className="text-muted">
+                          {m.input_municipal_tax_hint()}
+                        </Form.Text>
+                        {err && (
+                          <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>
+                        )}
+                      </Col>
+                    );
+                  }}
+                </form.Field>
               </>
             )}
           </Row>
@@ -202,97 +278,157 @@ export default function InputPanel({ inputs, onChange }: Props) {
         </Accordion.Header>
         <Accordion.Body>
           <Row className="g-3">
-            <Col xs={12}>
-              <Form.Label>{m.input_gross_salary()}</Form.Label>
-              <Form.Control
-                type="number"
-                min={0}
-                step={100}
-                value={inputs.grossSalary}
-                onChange={(e) => set("grossSalary", clampNumber(e.target.value))}
-                aria-describedby="gross-salary-hint"
-              />
-              <Form.Text id="gross-salary-hint" className="text-muted">
-                {m.input_gross_salary_hint()}
-              </Form.Text>
-            </Col>
+            <form.Field name="grossSalary" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12}>
+                    <Form.Label>{m.input_gross_salary()}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min={0}
+                      step={100}
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                      onBlur={field.handleBlur}
+                      isInvalid={!!err}
+                      aria-describedby="gross-salary-hint"
+                    />
+                    <Form.Text id="gross-salary-hint" className="text-muted">
+                      {m.input_gross_salary_hint()}
+                    </Form.Text>
+                    {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                  </Col>
+                );
+              }}
+            </form.Field>
 
-            <Col xs={12}>
-              <Form.Group controlId="withheldTaxNL">
-                <Form.Label>{m.input_withheld_tax_nl()}</Form.Label>
-                <Form.Control
-                  type="number"
-                  min={0}
-                  step={100}
-                  value={inputs.withheldTaxNL ?? 0}
-                  onChange={(e) => set("withheldTaxNL", clampNumber(e.target.value))}
-                  aria-describedby="withheld-tax-nl-hint"
-                />
-                <Form.Text id="withheld-tax-nl-hint" className="text-muted">
-                  {m.input_withheld_tax_nl_hint()}
-                </Form.Text>
-              </Form.Group>
-            </Col>
+            <form.Field name="withheldTaxNL" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12}>
+                    <Form.Group controlId="withheldTaxNL">
+                      <Form.Label>{m.input_withheld_tax_nl()}</Form.Label>
+                      <Form.Control
+                        type="number"
+                        min={0}
+                        step={100}
+                        value={field.state.value}
+                        onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                        onBlur={field.handleBlur}
+                        isInvalid={!!err}
+                        aria-describedby="withheld-tax-nl-hint"
+                      />
+                      <Form.Text id="withheld-tax-nl-hint" className="text-muted">
+                        {m.input_withheld_tax_nl_hint()}
+                      </Form.Text>
+                      {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                    </Form.Group>
+                  </Col>
+                );
+              }}
+            </form.Field>
 
-            <Col xs={12} sm={6}>
-              <Form.Label>{m.input_workdays_nl()}</Form.Label>
-              <Form.Control
-                type="number"
-                min={0}
-                value={inputs.daysWorkedNL}
-                onChange={(e) => set("daysWorkedNL", clampNumber(e.target.value))}
-                aria-describedby="workdays-nl-hint"
-              />
-              <Form.Text id="workdays-nl-hint" className="text-muted">
-                {m.input_workdays_nl_hint()}
-              </Form.Text>
-            </Col>
+            <form.Field name="daysWorkedNL" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12} sm={6}>
+                    <Form.Label>{m.input_workdays_nl()}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min={0}
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                      onBlur={field.handleBlur}
+                      isInvalid={!!err}
+                      aria-describedby="workdays-nl-hint"
+                    />
+                    <Form.Text id="workdays-nl-hint" className="text-muted">
+                      {m.input_workdays_nl_hint()}
+                    </Form.Text>
+                    {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                  </Col>
+                );
+              }}
+            </form.Field>
 
-            <Col xs={12} sm={6}>
-              <Form.Label>{m.input_workdays_be()}</Form.Label>
-              <Form.Control
-                type="number"
-                min={0}
-                value={inputs.daysWorkedBE}
-                onChange={(e) => set("daysWorkedBE", clampNumber(e.target.value))}
-              />
-            </Col>
+            <form.Field name="daysWorkedBE" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12} sm={6}>
+                    <Form.Label>{m.input_workdays_be()}</Form.Label>
+                    <Form.Control
+                      type="number"
+                      min={0}
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                      onBlur={field.handleBlur}
+                      isInvalid={!!err}
+                    />
+                    {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                  </Col>
+                );
+              }}
+            </form.Field>
 
-            <Col xs={12} sm={6}>
-              <Form.Group controlId="daysWorkedOther">
-                <Form.Label>{m.input_workdays_other()}</Form.Label>
-                <Form.Control
-                  type="number"
-                  min={0}
-                  value={inputs.daysWorkedOther ?? 0}
-                  onChange={(e) => set("daysWorkedOther", clampNumber(e.target.value))}
-                  aria-describedby="days-other-hint"
-                />
-                <Form.Text id="days-other-hint" className="text-muted">
-                  {m.input_workdays_other_hint()}
-                </Form.Text>
-              </Form.Group>
-            </Col>
+            <form.Field name="daysWorkedOther" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12} sm={6}>
+                    <Form.Group controlId="daysWorkedOther">
+                      <Form.Label>{m.input_workdays_other()}</Form.Label>
+                      <Form.Control
+                        type="number"
+                        min={0}
+                        value={field.state.value}
+                        onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                        onBlur={field.handleBlur}
+                        isInvalid={!!err}
+                        aria-describedby="days-other-hint"
+                      />
+                      <Form.Text id="days-other-hint" className="text-muted">
+                        {m.input_workdays_other_hint()}
+                      </Form.Text>
+                      {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                    </Form.Group>
+                  </Col>
+                );
+              }}
+            </form.Field>
 
-            <Col xs={12} sm={6}>
-              <Form.Group controlId="sickDays">
-                <Form.Label>{m.input_sick_days()}</Form.Label>
-                <Form.Control
-                  type="number"
-                  min={0}
-                  value={inputs.sickDays ?? 0}
-                  onChange={(e) => set("sickDays", clampNumber(e.target.value))}
-                  aria-describedby="sick-days-hint"
-                />
-                <Form.Text id="sick-days-hint" className="text-muted">
-                  {m.input_sick_days_hint()}
-                </Form.Text>
-              </Form.Group>
-            </Col>
+            <form.Field name="sickDays" validators={{ onChange: z.number().min(0) }}>
+              {(field) => {
+                const err = fieldError(field.state.meta.errors as unknown[]);
+                return (
+                  <Col xs={12} sm={6}>
+                    <Form.Group controlId="sickDays">
+                      <Form.Label>{m.input_sick_days()}</Form.Label>
+                      <Form.Control
+                        type="number"
+                        min={0}
+                        value={field.state.value}
+                        onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                        onBlur={field.handleBlur}
+                        isInvalid={!!err}
+                        aria-describedby="sick-days-hint"
+                      />
+                      <Form.Text id="sick-days-hint" className="text-muted">
+                        {m.input_sick_days_hint()}
+                      </Form.Text>
+                      {err && <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>}
+                    </Form.Group>
+                  </Col>
+                );
+              }}
+            </form.Field>
 
             <Col xs={12}>
               <div
-                className={`bt-workday-bar${totalWorkdays > maxWorkdaysInYear ? " bt-workday-bar--over" : ""}`}
+                className={clsx("bt-workday-bar", totalWorkdays > maxWorkdaysInYear && "bt-workday-bar--over")}
                 role="img"
                 aria-label={`${m.input_workdays_total()} ${totalWorkdays}`}
               >
@@ -302,7 +438,7 @@ export default function InputPanel({ inputs, onChange }: Props) {
                     style={{ width: `${nlBarW}%` }}
                   >
                     {nlBarW > 14 && (
-                      <span className="bt-workday-bar__label">{inputs.daysWorkedNL}</span>
+                      <span className="bt-workday-bar__label">{values.daysWorkedNL}</span>
                     )}
                   </div>
                 )}
@@ -312,7 +448,7 @@ export default function InputPanel({ inputs, onChange }: Props) {
                     style={{ width: `${beBarW}%` }}
                   >
                     {beBarW > 10 && (
-                      <span className="bt-workday-bar__label">{inputs.daysWorkedBE}</span>
+                      <span className="bt-workday-bar__label">{values.daysWorkedBE}</span>
                     )}
                   </div>
                 )}
@@ -325,11 +461,11 @@ export default function InputPanel({ inputs, onChange }: Props) {
               </div>
               <Form.Text
                 role="status"
-                className={
+                className={clsx(
                   totalWorkdays === 0 || totalWorkdays > maxWorkdaysInYear
                     ? "text-warning"
-                    : "text-muted"
-                }
+                    : "text-muted",
+                )}
               >
                 {m.input_workdays_total()} {totalWorkdays}
                 {totalWorkdays === 0 && ` — ${m.input_workdays_total_zero_warning()}`}
@@ -338,12 +474,12 @@ export default function InputPanel({ inputs, onChange }: Props) {
               <Form.Text className="text-muted d-block mt-1">
                 {m.input_workdays_typical()}
               </Form.Text>
-              {inputs.residentCountry === "BE" && totalWorkdays > 0 && beFraction >= 0.5 && (
+              {values.residentCountry === "BE" && totalWorkdays > 0 && beFraction >= 0.5 && (
                 <Alert variant="warning" className="mt-2 py-2 small mb-0">
                   {m.input_social_security_above_50()}
                 </Alert>
               )}
-              {inputs.residentCountry === "BE" &&
+              {values.residentCountry === "BE" &&
                 totalWorkdays > 0 &&
                 beFraction >= 0.25 &&
                 beFraction < 0.5 && (
@@ -353,20 +489,24 @@ export default function InputPanel({ inputs, onChange }: Props) {
                 )}
             </Col>
 
-            <Col xs={12}>
-              <Form.Check
-                id="thirty-ruling"
-                label={m.input_thirty_percent_ruling()}
-                checked={inputs.thirtyPercentRuling}
-                onChange={(e) => set("thirtyPercentRuling", e.target.checked)}
-                aria-describedby="thirty-ruling-hint"
-              />
-              <Form.Text id="thirty-ruling-hint" className="text-muted">
-                {m.input_thirty_percent_ruling_hint()}
-              </Form.Text>
-            </Col>
+            <form.Field name="thirtyPercentRuling">
+              {(field) => (
+                <Col xs={12}>
+                  <Form.Check
+                    id="thirty-ruling"
+                    label={m.input_thirty_percent_ruling()}
+                    checked={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.checked)}
+                    aria-describedby="thirty-ruling-hint"
+                  />
+                  <Form.Text id="thirty-ruling-hint" className="text-muted">
+                    {m.input_thirty_percent_ruling_hint()}
+                  </Form.Text>
+                </Col>
+              )}
+            </form.Field>
 
-            {inputs.residentCountry === "BE" && (
+            {values.residentCountry === "BE" && (
               <>
                 {(
                   [
@@ -387,24 +527,35 @@ export default function InputPanel({ inputs, onChange }: Props) {
                       label: m.input_roerende_voorheffing(),
                     },
                   ] as const satisfies readonly { key: BelgianDeductionKey; label: string }[]
-                ).map((field) => (
-                  <Col key={field.key} xs={12} sm={6}>
-                    <Form.Group controlId={field.key}>
-                      <Form.Label>{field.label}</Form.Label>
-                      <Form.Control
-                        type="number"
-                        min={0}
-                        step={100}
-                        value={inputs[field.key] ?? 0}
-                        onChange={(e) =>
-                          set(
-                            field.key,
-                            clampNumber(e.target.value) as TaxInputs[BelgianDeductionKey],
-                          )
-                        }
-                      />
-                    </Form.Group>
-                  </Col>
+                ).map((fieldDef) => (
+                  <form.Field
+                    key={fieldDef.key}
+                    name={fieldDef.key}
+                    validators={{ onChange: z.number().min(0) }}
+                  >
+                    {(field) => {
+                      const err = fieldError(field.state.meta.errors as unknown[]);
+                      return (
+                        <Col xs={12} sm={6}>
+                          <Form.Group controlId={fieldDef.key}>
+                            <Form.Label>{fieldDef.label}</Form.Label>
+                            <Form.Control
+                              type="number"
+                              min={0}
+                              step={100}
+                              value={field.state.value}
+                              onChange={(e) => field.handleChange(Number(e.target.value) || 0)}
+                              onBlur={field.handleBlur}
+                              isInvalid={!!err}
+                            />
+                            {err && (
+                              <Form.Control.Feedback type="invalid">{err}</Form.Control.Feedback>
+                            )}
+                          </Form.Group>
+                        </Col>
+                      );
+                    }}
+                  </form.Field>
                 ))}
               </>
             )}

--- a/src/components/MultiYearComparison.tsx
+++ b/src/components/MultiYearComparison.tsx
@@ -1,4 +1,5 @@
 import { Badge, Table } from "react-bootstrap";
+import clsx from "clsx";
 import { VALID_YEARS } from "../tax/constants";
 import type { TaxYear } from "../tax/constants";
 import type { TaxResult } from "../tax/types";
@@ -33,7 +34,7 @@ export default function MultiYearComparison({ rows, activeYear }: Props) {
           return (
             <div
               key={year}
-              className={`bt-year-chart__row${isActive ? " bt-year-chart__row--active" : ""}`}
+              className={clsx("bt-year-chart__row", isActive && "bt-year-chart__row--active")}
             >
               <div className="bt-year-chart__label">
                 {year}
@@ -92,7 +93,7 @@ export default function MultiYearComparison({ rows, activeYear }: Props) {
         </thead>
         <tbody>
           {rows.map(({ year, result }) => (
-            <tr key={year} className={year === activeYear ? "table-primary" : undefined}>
+            <tr key={year} className={clsx(year === activeYear && "table-primary")}>
               <td>
                 {year} {year === activeYear && <Badge bg="primary">{m.years_active()}</Badge>}
               </td>

--- a/src/components/NLResult.tsx
+++ b/src/components/NLResult.tsx
@@ -1,4 +1,5 @@
 import { Badge, Table } from "react-bootstrap";
+import clsx from "clsx";
 import type { NLTaxResult } from "../tax/types";
 import * as m from "../paraglide/messages.js";
 import { fmtExact as fmt, pctExact as pct } from "./format.js";
@@ -110,9 +111,9 @@ export default function NLResult({
                 <td>{m.nl_withheld()}</td>
                 <td className="text-end">{fmt(withheldTaxNL)}</td>
               </tr>
-              <tr className={`fw-bold ${nlBalance >= 0 ? "table-success" : "table-danger"}`}>
+              <tr className={clsx("fw-bold", nlBalance >= 0 ? "table-success" : "table-danger")}>
                 <td>{nlBalance >= 0 ? m.nl_balance_refund() : m.nl_balance_due()}</td>
-                <td className={`text-end ${nlBalance >= 0 ? "text-success" : "text-danger"}`}>
+                <td className={clsx("text-end", nlBalance >= 0 ? "text-success" : "text-danger")}>
                   {nlBalance >= 0 ? "+" : "−"}
                   {fmt(Math.abs(nlBalance))}
                 </td>

--- a/src/components/SummaryResult.tsx
+++ b/src/components/SummaryResult.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Alert, Button, Col, Row, Stack } from "react-bootstrap";
+import clsx from "clsx";
 import type { TaxResult } from "../tax/types";
 import { getTotalWorkdays } from "../tax/workdays";
 import * as m from "../paraglide/messages.js";
@@ -267,13 +268,13 @@ export default function SummaryResult({ result, onResetInputs }: Props) {
               <span className="bt-breakdown__value text-danger">−{fmt(nl.netTaxNL)}</span>
             </div>
             <div
-              className={`bt-breakdown__row ${nlBalance >= 0 ? "bt-breakdown__row--ok" : "bt-breakdown__row--warn"}`}
+              className={clsx("bt-breakdown__row", nlBalance >= 0 ? "bt-breakdown__row--ok" : "bt-breakdown__row--warn")}
             >
               <span className="bt-breakdown__label bt-breakdown__label--strong">
                 🇳🇱 {m.summary_nl_balance()}
               </span>
               <span
-                className={`bt-breakdown__value bt-breakdown__label--strong ${nlBalance >= 0 ? "text-success" : "text-danger"}`}
+                className={clsx("bt-breakdown__value", "bt-breakdown__label--strong", nlBalance >= 0 ? "text-success" : "text-danger")}
               >
                 {fmtSigned(nlBalance)}
               </span>
@@ -287,7 +288,7 @@ export default function SummaryResult({ result, onResetInputs }: Props) {
           </div>
 
           <div
-            className={`bt-balance ${netResult >= 0 ? "bt-balance--refund" : "bt-balance--owe"}`}
+            className={clsx("bt-balance", netResult >= 0 ? "bt-balance--refund" : "bt-balance--owe")}
           >
             <div className="bt-balance__label">
               <i

--- a/src/components/WFHRatioChart.tsx
+++ b/src/components/WFHRatioChart.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { Badge, Table } from "react-bootstrap";
+import clsx from "clsx";
 import {
   Area,
   CartesianGrid,
@@ -181,7 +182,7 @@ export default function WFHRatioChart({ inputs }: Props) {
               data={data}
               margin={{ top: 16, right: 16, bottom: 32, left: 56 }}
               onMouseMove={(state) => {
-                if (state.isTooltipActive && typeof state.activeTooltipIndex === "number") {
+                if (state?.isTooltipActive && typeof state?.activeTooltipIndex === "number") {
                   setHovered(state.activeTooltipIndex);
                 }
               }}
@@ -454,11 +455,11 @@ export default function WFHRatioChart({ inputs }: Props) {
         </div>
 
         {/* ── Readout bar ───────────────────────────────────────────── */}
-        <div className={`bt-wfh-readout${isHovering ? " bt-wfh-readout--visible" : ""}`}>
+        <div className={clsx("bt-wfh-readout", isHovering && "bt-wfh-readout--visible")}>
           {displayPoint ? (
             <>
               <span
-                className={`bt-wfh-readout__label${isHovering ? "" : " bt-wfh-readout__label--current"}`}
+                className={clsx("bt-wfh-readout__label", !isHovering && "bt-wfh-readout__label--current")}
               >
                 {!isHovering && (
                   <span className="bt-wfh-readout__tag">{m.wfh_current_ratio()}</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -58,7 +58,7 @@
   --bt-warning-border: rgba(245, 158, 11, 0.3);
 
   /* Typography */
-  --bt-font-body: "Inter Variable", "Inter", system-ui, -apple-system, sans-serif;
+  --bt-font-body: "Inter Variable", system-ui, -apple-system, sans-serif;
   --bt-font-mono: "Space Mono", "Courier New", monospace;
 
   /* Radii */
@@ -1350,6 +1350,7 @@ footer a:hover {
   background: var(--bt-surface-2);
   border: 1px solid var(--bt-border);
   cursor: crosshair;
+  touch-action: pan-y;
 }
 
 /* Suppress the default recharts tooltip wrapper box */

--- a/src/tax/schema.ts
+++ b/src/tax/schema.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import {
+  VALID_BELGIAN_REGIONS,
+  VALID_CIVIL_STATUSES,
+  VALID_RESIDENT_COUNTRIES,
+} from "./constants";
+
+export const TaxInputSchema = z.object({
+  year: z
+    .union([
+      z.literal(2020),
+      z.literal(2021),
+      z.literal(2022),
+      z.literal(2023),
+      z.literal(2024),
+      z.literal(2025),
+    ])
+    .catch(2025),
+  residentCountry: z.enum(VALID_RESIDENT_COUNTRIES).catch("BE"),
+  civilStatus: z.enum(VALID_CIVIL_STATUSES).catch("single"),
+  dependentChildren: z
+    .number()
+    .catch(0)
+    .transform((v) => Math.min(10, Math.max(0, v))),
+  belowAOWAge: z.boolean().catch(true),
+  belgianRegion: z.enum(VALID_BELGIAN_REGIONS).catch("flemish"),
+  communalTaxRate: z
+    .number()
+    .catch(7)
+    .transform((v) => Math.min(15, Math.max(0, v))),
+  grossSalary: z.number().catch(60000).transform((v) => Math.max(0, v)),
+  daysWorkedNL: z.number().catch(200).transform((v) => Math.max(0, v)),
+  daysWorkedBE: z.number().catch(20).transform((v) => Math.max(0, v)),
+  daysWorkedOther: z.number().catch(0).transform((v) => Math.max(0, v)),
+  thirtyPercentRuling: z.boolean().catch(false),
+  socialContributions: z.number().catch(0).transform((v) => Math.max(0, v)),
+  aanvullendPensioen: z.number().catch(0).transform((v) => Math.max(0, v)),
+  dienstencheques: z.number().catch(0).transform((v) => Math.max(0, v)),
+  roerendeVoorheffing: z.number().catch(0).transform((v) => Math.max(0, v)),
+  withheldTaxNL: z.number().catch(0).transform((v) => Math.max(0, v)),
+  sickDays: z.number().catch(0).transform((v) => Math.max(0, v)),
+});
+
+export const PersistedInputsSchema = TaxInputSchema.pick({
+  year: true,
+  residentCountry: true,
+  civilStatus: true,
+  dependentChildren: true,
+  belowAOWAge: true,
+  belgianRegion: true,
+  communalTaxRate: true,
+  thirtyPercentRuling: true,
+});
+
+export type TaxInputs = z.infer<typeof TaxInputSchema>;
+export type PersistedInputs = z.infer<typeof PersistedInputsSchema>;

--- a/src/tax/types.ts
+++ b/src/tax/types.ts
@@ -1,37 +1,5 @@
-import type { TaxYear, ResidentCountry, CivilStatus, BelgianRegion } from "./constants";
-
-export interface TaxInputs {
-  year: TaxYear;
-  residentCountry: ResidentCountry;
-  civilStatus: CivilStatus;
-  dependentChildren: number;
-  belowAOWAge: boolean;
-  belgianRegion: BelgianRegion;
-  /** Municipal tax rate as a percentage, e.g. 7 for 7%. Typical Belgian range: 0–9%. */
-  communalTaxRate: number;
-  grossSalary: number;
-  daysWorkedNL: number;
-  daysWorkedBE: number;
-  /** Days worked in a third country (e.g. customer installation in France).
-   *  Belgium treats these identically to Belgian days (vol tarief) since the NL-BE treaty
-   *  only covers NL-sourced income. Default 0. */
-  daysWorkedOther?: number;
-  thirtyPercentRuling: boolean;
-  /** Belgian social contributions (eigen bijdragen) — deductible from Belgian declared income. Default 0. */
-  socialContributions?: number;
-  /** Supplementary pension contributions (code 1285) — 30% reduction applies. Default 0. */
-  aanvullendPensioen?: number;
-  /** Diensten-cheques amount (code 3364) — 20% reduction applies. Default 0. */
-  dienstencheques?: number;
-  /** Roerende voorheffing / withholding tax already paid (code 1437). Default 0. */
-  roerendeVoorheffing?: number;
-  /** NL wage tax withheld by employer (ingehouden loonheffing from jaaropgave).
-   *  Used to compute NL refund/payment and net eindafrekening. Default 0. */
-  withheldTaxNL?: number;
-  /** Sick days during the year. NL and BE use different methods to account for sick days
-   *  when calculating the income sourcing fraction. Default 0. */
-  sickDays?: number;
-}
+import type { TaxInputs } from "./schema";
+export type { TaxInputs };
 
 export interface BracketLine {
   label: string;

--- a/tests/components/InputPanel.test.tsx
+++ b/tests/components/InputPanel.test.tsx
@@ -1,10 +1,24 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useForm } from "@tanstack/react-form";
 
-import InputPanel from "@/components/InputPanel";
+import InputPanel, { type TaxFormApi } from "@/components/InputPanel";
 import type { TaxInputs } from "@/tax/types";
 import { setLocale } from "@/paraglide/runtime";
 import { mockInputs } from "../test-utils/mockData";
+
+function renderInputPanel(overrides: Partial<TaxInputs> = {}) {
+  let formInstance!: TaxFormApi;
+
+  function Wrapper() {
+    const form = useForm({ defaultValues: { ...mockInputs, ...overrides } });
+    formInstance = form as TaxFormApi;
+    return <InputPanel form={formInstance} />;
+  }
+
+  render(<Wrapper />);
+  return { getForm: () => formInstance };
+}
 
 describe("InputPanel", () => {
   beforeEach(() => {
@@ -12,13 +26,11 @@ describe("InputPanel", () => {
   });
 
   it("renders without crashing", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+    renderInputPanel();
   });
 
   it("shows communal tax field for BE residents", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={{ ...mockInputs, residentCountry: "BE" }} onChange={onChange} />);
+    renderInputPanel({ residentCountry: "BE" });
     // Year is the only combobox shown (resident country, civil status and Belgian region
     // dropdowns are hidden when there is only one valid option each)
     const selects = screen.getAllByRole("combobox");
@@ -27,168 +39,131 @@ describe("InputPanel", () => {
     expect(screen.getAllByRole("spinbutton").length).toBeGreaterThanOrEqual(5);
   });
 
-  it("calls onChange when year dropdown is changed", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates year when dropdown is changed", () => {
+    const { getForm } = renderInputPanel();
     const selects = screen.getAllByRole("combobox");
     fireEvent.change(selects[0]!, { target: { value: "2024" } });
-    expect(onChange).toHaveBeenCalledOnce();
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ year: 2024 }));
+    expect(getForm().getFieldValue("year")).toBe(2024);
   });
 
   // TODO: Re-enable when NL-resident support is re-integrated
   it.skip("hides Belgian region and communal tax fields for NL residents", () => {
-    const onChange = vi.fn();
-    const nlInputs = { ...mockInputs, residentCountry: "NL" as unknown as TaxInputs["residentCountry"] };
-    render(<InputPanel inputs={nlInputs} onChange={onChange} />);
+    renderInputPanel({
+      residentCountry: "NL" as unknown as TaxInputs["residentCountry"],
+    });
     const selects = screen.getAllByRole("combobox");
     expect(selects.length).toBe(3);
     expect(screen.queryByText(/municipal tax|communal tax|gemeentebelasting/i)).toBeNull();
-    // Sick days field should be present for NL residents
     expect(screen.getByRole("spinbutton", { name: /sick days/i })).toBeInTheDocument();
-    // Municipal/communal tax spinbutton should not be rendered for NL residents
     expect(screen.queryByRole("spinbutton", { name: /municipal tax|communal tax/i })).toBeNull();
   });
 
   // TODO: Re-enable when NL-resident support is re-integrated
-  it.skip("calls onChange when resident country changes to NL", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it.skip("updates resident country to NL", () => {
+    const { getForm } = renderInputPanel();
     const selects = screen.getAllByRole("combobox");
     fireEvent.change(selects[1]!, { target: { value: "NL" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ residentCountry: "NL" }));
+    expect(getForm().getFieldValue("residentCountry")).toBe("NL");
   });
 
   // TODO: Re-enable when multiple civil statuses are supported
-  it.skip("calls onChange when civil status changes", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it.skip("updates civil status", () => {
+    const { getForm } = renderInputPanel();
     const selects = screen.getAllByRole("combobox");
     fireEvent.change(selects[2]!, { target: { value: "married" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ civilStatus: "married" }));
+    expect(getForm().getFieldValue("civilStatus")).toBe("married");
   });
 
   // TODO: Re-enable when multiple Belgian regions are supported
-  it.skip("calls onChange when belgian region changes", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={{ ...mockInputs, residentCountry: "BE" }} onChange={onChange} />);
+  it.skip("updates belgian region", () => {
+    const { getForm } = renderInputPanel({ residentCountry: "BE" });
     const selects = screen.getAllByRole("combobox");
-    // belgianRegion is the 4th dropdown (index 3)
     fireEvent.change(selects[3]!, { target: { value: "walloon" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ belgianRegion: "walloon" }));
+    expect(getForm().getFieldValue("belgianRegion")).toBe("walloon");
   });
 
-  it("calls onChange when communal tax rate changes", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={{ ...mockInputs, residentCountry: "BE" }} onChange={onChange} />);
+  it("updates communal tax rate", () => {
+    const { getForm } = renderInputPanel({ residentCountry: "BE" });
     // For BE resident: spinbuttons are [dependentChildren, communalTaxRate, grossSalary, daysWorkedNL, daysWorkedBE]
     const inputs = screen.getAllByRole("spinbutton");
     fireEvent.change(inputs[1]!, { target: { value: "8" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ communalTaxRate: 8 }));
+    expect(getForm().getFieldValue("communalTaxRate")).toBe(8);
   });
 
-  it("calls onChange when gross salary is updated", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates gross salary", () => {
+    const { getForm } = renderInputPanel();
     // For BE resident: spinbuttons are [dependentChildren, communalTaxRate, grossSalary, daysWorkedNL, daysWorkedBE]
     const inputs = screen.getAllByRole("spinbutton");
     const grossSalaryInput = inputs[2]!;
     fireEvent.change(grossSalaryInput, { target: { value: "80000" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ grossSalary: 80000 }));
+    expect(getForm().getFieldValue("grossSalary")).toBe(80000);
   });
 
-  it("calls onChange when daysWorkedNL is updated", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates daysWorkedNL", () => {
+    const { getForm } = renderInputPanel();
     const inputs = screen.getAllByRole("spinbutton");
     fireEvent.change(inputs[4]!, { target: { value: "150" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ daysWorkedNL: 150 }));
+    expect(getForm().getFieldValue("daysWorkedNL")).toBe(150);
   });
 
-  it("calls onChange when daysWorkedBE is updated", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates daysWorkedBE", () => {
+    const { getForm } = renderInputPanel();
     const inputs = screen.getAllByRole("spinbutton");
     fireEvent.change(inputs[5]!, { target: { value: "30" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ daysWorkedBE: 30 }));
+    expect(getForm().getFieldValue("daysWorkedBE")).toBe(30);
   });
 
-  it("calls onChange when AOW checkbox is toggled", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates belowAOWAge when checkbox is toggled", () => {
+    const { getForm } = renderInputPanel();
     const checkbox = screen.getByRole("checkbox", { name: /aow/i });
     fireEvent.click(checkbox);
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ belowAOWAge: false }));
+    expect(getForm().getFieldValue("belowAOWAge")).toBe(false);
   });
 
-  it("calls onChange when thirty percent ruling is toggled", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates thirtyPercentRuling when checkbox is toggled", () => {
+    const { getForm } = renderInputPanel();
     const checkboxes = screen.getAllByRole("checkbox");
     // thirtyPercentRuling checkbox is the second checkbox
     fireEvent.click(checkboxes[1]!);
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ thirtyPercentRuling: true }));
+    expect(getForm().getFieldValue("thirtyPercentRuling")).toBe(true);
   });
 
-  it("calls onChange when dependents count is updated", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
+  it("updates dependents count", () => {
+    const { getForm } = renderInputPanel();
     const inputs = screen.getAllByRole("spinbutton");
     fireEvent.change(inputs[0]!, { target: { value: "2" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ dependentChildren: 2 }));
+    expect(getForm().getFieldValue("dependentChildren")).toBe(2);
   });
 
-  it("clamps dependent children to the allowed maximum", () => {
-    const onChange = vi.fn();
-    render(<InputPanel inputs={mockInputs} onChange={onChange} />);
-    const inputs = screen.getAllByRole("spinbutton");
-    fireEvent.change(inputs[0]!, { target: { value: "99" } });
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ dependentChildren: 10 }));
+  it("allows out-of-range dependents and surfaces a validation error", () => {
+    const { getForm } = renderInputPanel();
+    const spinButtons = screen.getAllByRole("spinbutton");
+    fireEvent.change(spinButtons[0]!, { target: { value: "99" } });
+    // Raw form value is unclamped — clamping happens at the App layer via TaxInputSchema.parse
+    expect(getForm().getFieldValue("dependentChildren")).toBe(99);
+    // Zod validator marks the input as invalid
+    expect(spinButtons[0]).toHaveClass("is-invalid");
   });
 
   it("shows total workdays count", () => {
-    const onChange = vi.fn();
-    render(
-      <InputPanel
-        inputs={{ ...mockInputs, daysWorkedNL: 180, daysWorkedBE: 20, daysWorkedOther: 5 }}
-        onChange={onChange}
-      />,
-    );
+    renderInputPanel({ daysWorkedNL: 180, daysWorkedBE: 20, daysWorkedOther: 5 });
     // 180 + 20 + 5 = 205 — shown inline as "Total workdays: 205"
     expect(screen.getByText(/205/)).toBeInTheDocument();
   });
 
   it("shows a warning when total workdays is zero", () => {
-    const onChange = vi.fn();
-    render(
-      <InputPanel
-        inputs={{ ...mockInputs, daysWorkedNL: 0, daysWorkedBE: 0, daysWorkedOther: 0 }}
-        onChange={onChange}
-      />,
-    );
+    renderInputPanel({ daysWorkedNL: 0, daysWorkedBE: 0, daysWorkedOther: 0 });
     expect(screen.getByText(/realistic net\/day|realistische netto\/dag/i)).toBeInTheDocument();
   });
 
   it("shows a warning when workdays total exceeds a typical yearly range", () => {
-    const onChange = vi.fn();
-    render(
-      <InputPanel
-        inputs={{ ...mockInputs, daysWorkedNL: 260, daysWorkedBE: 120, daysWorkedOther: 20 }}
-        onChange={onChange}
-      />,
-    );
+    renderInputPanel({ daysWorkedNL: 260, daysWorkedBE: 120, daysWorkedOther: 20 });
     expect(screen.getByText(/total workdays|totaal aantal werkdagen/i)).toBeInTheDocument();
     expect(screen.getByText(/double-check|controleer/i)).toBeInTheDocument();
   });
 
   it("does not show high workdays warning when total is within normal range", () => {
-    const onChange = vi.fn();
-    render(
-      <InputPanel
-        inputs={{ ...mockInputs, daysWorkedNL: 200, daysWorkedBE: 20, daysWorkedOther: 0 }}
-        onChange={onChange}
-      />,
-    );
+    renderInputPanel({ daysWorkedNL: 200, daysWorkedBE: 20, daysWorkedOther: 0 });
     expect(screen.queryByText(/double-check|controleer/i)).toBeNull();
   });
 });

--- a/tests/tax/be.test.ts
+++ b/tests/tax/be.test.ts
@@ -15,11 +15,14 @@ const base: TaxInputs = {
   grossSalary: 60000,
   daysWorkedNL: 220,
   daysWorkedBE: 0,
+  daysWorkedOther: 0,
   thirtyPercentRuling: false,
   socialContributions: 0,
   aanvullendPensioen: 0,
   dienstencheques: 0,
   roerendeVoorheffing: 0,
+  withheldTaxNL: 0,
+  sickDays: 0,
 };
 
 function mockNL(overrides?: Partial<NLTaxResult>): NLTaxResult {

--- a/tests/tax/index.test.ts
+++ b/tests/tax/index.test.ts
@@ -14,7 +14,14 @@ const base: TaxInputs = {
   grossSalary: 60000,
   daysWorkedNL: 220,
   daysWorkedBE: 0,
+  daysWorkedOther: 0,
   thirtyPercentRuling: false,
+  socialContributions: 0,
+  aanvullendPensioen: 0,
+  dienstencheques: 0,
+  roerendeVoorheffing: 0,
+  withheldTaxNL: 0,
+  sickDays: 0,
 };
 
 describe("calculate", () => {

--- a/tests/tax/nl.test.ts
+++ b/tests/tax/nl.test.ts
@@ -14,7 +14,14 @@ const base: TaxInputs = {
   grossSalary: 60000,
   daysWorkedNL: 220,
   daysWorkedBE: 0,
+  daysWorkedOther: 0,
   thirtyPercentRuling: false,
+  socialContributions: 0,
+  aanvullendPensioen: 0,
+  dienstencheques: 0,
+  roerendeVoorheffing: 0,
+  withheldTaxNL: 0,
+  sickDays: 0,
 };
 
 describe("calculateNLTax", () => {

--- a/tests/tax/workdays.test.ts
+++ b/tests/tax/workdays.test.ts
@@ -30,6 +30,12 @@ describe("getTotalWorkdays", () => {
         daysWorkedBE: 10,
         daysWorkedOther: 5,
         thirtyPercentRuling: false,
+        socialContributions: 0,
+        aanvullendPensioen: 0,
+        dienstencheques: 0,
+        roerendeVoorheffing: 0,
+        withheldTaxNL: 0,
+        sickDays: 0,
       }),
     ).toBe(235);
   });

--- a/tests/test-utils/mockData.ts
+++ b/tests/test-utils/mockData.ts
@@ -11,11 +11,14 @@ export const mockInputs: TaxInputs = {
   grossSalary: 60000,
   daysWorkedNL: 200,
   daysWorkedBE: 20,
+  daysWorkedOther: 0,
   thirtyPercentRuling: false,
   socialContributions: 0,
   aanvullendPensioen: 0,
   dienstencheques: 0,
   roerendeVoorheffing: 0,
+  withheldTaxNL: 0,
+  sickDays: 0,
 };
 
 export const mockNLResult: NLTaxResult = {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #110

- Adds `zod` as a runtime dependency and introduces `src/tax/schema.ts` with `TaxInputSchema` encoding all validation rules (enum membership, boolean coercion, numeric clamping) via `.catch()` and `.transform()`
- `TaxInputs` is derived from `z.infer<typeof TaxInputSchema>`; previously-optional fields (`daysWorkedOther`, `withheldTaxNL`, `sickDays`, etc.) are now required in the type since the schema always provides defaults
- `PersistedInputsSchema = TaxInputSchema.pick({…})` replaces the hand-rolled `Pick<TaxInputs, …>` type and the manual field enumeration in `toPersistedInputs`
- Removes the 60-line `sanitizeInputs` function and the `TaxInputsWithRequiredBEDeductions` helper type from `App.tsx`; `mergeWithDefaults` now delegates to `PersistedInputsSchema.parse`
- Test fixtures updated to supply the now-required fields

## Test plan

- [ ] All 119 existing tests pass (`pnpm test`)
- [ ] TypeScript type check passes (`pnpm typecheck`)
- [ ] Load app, verify localStorage round-trip works (save settings, reload, settings persist)
- [ ] Verify invalid/corrupted localStorage gracefully falls back to defaults

https://claude.ai/code/session_01Rz6wvUcT4eyoRqCRJBfrro
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rz6wvUcT4eyoRqCRJBfrro)_